### PR TITLE
Use strides in matmul

### DIFF
--- a/src/backend/cpu/kernel.rs
+++ b/src/backend/cpu/kernel.rs
@@ -43,15 +43,15 @@ fn matmul<T: Numeric + 'static>(
             n,                   // n: cols in matrices B and C
             k,                   // k: cols in A, rows in B
             c.data.as_mut_ptr(), // c: pointer to result matrix C
-            1,                   // column stride for C
-            n as isize,          // row stride for C
+            c.strides[1],        // column stride for C
+            c.strides[0],        // row stride for C
             false,               // read C
             a.data.as_ptr(),     // a: pointer to first matrix A
-            1,                   // column stride for A
-            k as isize,          // row stride for A
+            a.strides[1],        // column stride for A
+            a.strides[0],        // row stride for A
             b.data.as_ptr(),     // b: pointer to second matrix B
-            1,                   // column stride for B
-            n as isize,          // row stride for B
+            b.strides[1],        // column stride for B
+            b.strides[0],        // row stride for B
             T::zero(),           // alpha scaling factor for A*B
             T::one(),            // beta scaling factor for C
             false,               // conj C


### PR DESCRIPTION
Add strides to the ArraySlice structs so gemm works with transposed matrices.

strides are isize in gemm because they are involved in pointer arithmetic.
It may have been cleaner to just leave them as usize and only transform to isize in the gemm call. Not sure.