### PR TITLE
Infer one dimension for reshape

### DIFF
--- a/src/backend/cpu/eval.rs
+++ b/src/backend/cpu/eval.rs
@@ -853,6 +853,70 @@ mod test {
     }
 
     #[test]
+    fn test_reshape_multiple() {
+        let f = Operation::reshape(
+            NdArrayType {
+                shape: Shape(vec![4, 3]),
+                dtype: Dtype::I32,
+            },
+            Shape(vec![2, 2, 3]),
+        );
+
+        let x = NdArray::new((0..12).collect(), Shape(vec![4, 3]));
+
+        let expected = NdArray::new((0..12).collect(), Shape(vec![2, 2, 3]));
+
+        let mut state = EvalState::from_lax(f);
+
+        let [actual] = state.eval_with(vec![x.into()])[..] else {
+            panic!("unexpected coarity at eval time")
+        };
+
+        assert_eq!(actual, &expected.into());
+    }
+
+    #[test]
+    fn test_reshape_inferred_dim() {
+        let f = Operation::reshape(
+            NdArrayType {
+                shape: Shape(vec![4, 3]),
+                dtype: Dtype::I32,
+            },
+            Shape(vec![2, 0]),
+        );
+
+        let x = NdArray::new((0..12).collect(), Shape(vec![4, 3]));
+
+        let expected = NdArray::new((0..12).collect(), Shape(vec![2, 6]));
+
+        let mut state = EvalState::from_lax(f);
+
+        let [actual] = state.eval_with(vec![x.into()])[..] else {
+            panic!("unexpected coarity at eval time")
+        };
+
+        assert_eq!(actual, &expected.into());
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_reshape_multiple_inferred_dims() {
+        let f = Operation::reshape(
+            NdArrayType {
+                shape: Shape(vec![4, 3]),
+                dtype: Dtype::I32,
+            },
+            Shape(vec![0, 0, 3]),
+        );
+
+        let x = NdArray::new((0..12).collect(), Shape(vec![4, 3]));
+
+        let mut state = EvalState::from_lax(f);
+
+        state.eval_with(vec![x.into()]);
+    }
+
+    #[test]
     #[should_panic]
     fn test_reshape_invalid_shape() {
         let f = Operation::reshape(


### PR DESCRIPTION
Ex: Reshape [2,8] -> [2,0,4] is equivalent to Reshape [2,8] -> [2,2,4]

Ideally this should use -1 like torch and not 0 to specify the dimension to be inferred. That needs changing the current usize/Nat args in many places.