### PR TITLE
egglog good?

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,6 +104,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
+name = "bitmaps"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,7 +144,7 @@ checksum = "7ecc273b49b3205b83d648f0690daa588925572cc5063745bfe547fe7ec8e1a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -140,10 +164,12 @@ name = "catgrad"
 version = "0.1.0"
 dependencies = [
  "clap",
- "env_logger",
+ "egglog",
+ "env_logger 0.11.8",
  "gemm",
  "half",
  "hf-hub",
+ "lazy_static",
  "log",
  "memmap2",
  "num-traits",
@@ -169,6 +195,15 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "clap"
@@ -201,7 +236,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -227,6 +262,15 @@ dependencies = [
  "once_cell",
  "unicode-width",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -270,6 +314,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,7 +344,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -301,7 +355,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -322,7 +376,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -332,7 +386,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -364,8 +428,23 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
+
+[[package]]
+name = "dot-generator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aaac7ada45f71873ebce336491d1c1bc4a7c8042c7cea978168ad59e805b871"
+dependencies = [
+ "dot-structures",
+]
+
+[[package]]
+name = "dot-structures"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cfcded997a93eb31edd639361fa33fd229a8784e953b37d71035fe3890b7b"
 
 [[package]]
 name = "dyn-stack"
@@ -374,6 +453,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490bd48eb68fffcfed519b4edbfd82c69cbe741d175b84f0e0cbe8c57cbe0bdd"
 dependencies = [
  "bytemuck",
+]
+
+[[package]]
+name = "egglog"
+version = "0.4.0"
+dependencies = [
+ "chrono",
+ "clap",
+ "egraph-serialize",
+ "env_logger 0.10.2",
+ "hashbrown",
+ "im",
+ "im-rc",
+ "indexmap",
+ "instant",
+ "lazy_static",
+ "log",
+ "num",
+ "ordered-float",
+ "rustc-hash",
+ "smallvec",
+ "symbol_table",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "egraph-serialize"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31c5c0d7f760f9c1c84e21d73dcd3b3ce7a4770c27689f56a0db26e0f3e79ca"
+dependencies = [
+ "graphviz-rust",
+ "indexmap",
+ "once_cell",
+ "ordered-float",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -397,7 +513,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -408,6 +524,19 @@ checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
 dependencies = [
  "log",
  "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
 ]
 
 [[package]]
@@ -424,6 +553,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "esaxx-rs"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,6 +576,12 @@ checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "flate2"
@@ -447,6 +598,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -577,6 +734,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -584,7 +751,35 @@ checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
+]
+
+[[package]]
+name = "graphviz-rust"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27dafd1ac303e0dfb347a3861d9ac440859bab26ec2f534bbceb262ea492a1e0"
+dependencies = [
+ "dot-generator",
+ "dot-structures",
+ "into-attr",
+ "into-attr-derive",
+ "pest",
+ "pest_derive",
+ "rand",
+ "tempfile",
 ]
 
 [[package]]
@@ -600,10 +795,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
 
 [[package]]
 name = "hf-hub"
@@ -634,6 +846,12 @@ dependencies = [
  "fnv",
  "itoa",
 ]
+
+[[package]]
+name = "humantime"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
 
 [[package]]
 name = "icu_collections"
@@ -750,7 +968,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -781,6 +999,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "im"
+version = "15.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
+dependencies = [
+ "bitmaps",
+ "rand_core",
+ "rand_xoshiro",
+ "sized-chunks",
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "im-rc"
+version = "15.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1955a75fa080c677d3972822ec4bad316169ab1cfc6c257a942c2265dbe5fe"
+dependencies = [
+ "bitmaps",
+ "rand_core",
+ "rand_xoshiro",
+ "sized-chunks",
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+ "serde",
+]
+
+[[package]]
 name = "indicatif"
 version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -791,6 +1048,48 @@ dependencies = [
  "portable-atomic",
  "unicode-width",
  "web-time",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "into-attr"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18b48c537e49a709e678caec3753a7dba6854661a1eaa27675024283b3f8b376"
+dependencies = [
+ "dot-structures",
+]
+
+[[package]]
+name = "into-attr-derive"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecac7c1ae6cd2c6a3a64d1061a8bdc7f52ff62c26a831a2301e54c1b5d70d5b1"
+dependencies = [
+ "dot-generator",
+ "dot-structures",
+ "into-attr",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -844,7 +1143,7 @@ checksum = "f3c30758ddd7188629c6713fc45d1188af4f44c90582311d0c8d8c9907f60c48"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -884,6 +1183,12 @@ dependencies = [
  "bitflags 2.9.0",
  "libc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
@@ -970,7 +1275,7 @@ checksum = "c402a4092d5e204f32c9e155431046831fa712637043c58cb73bc6bc6c9663b5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -994,12 +1299,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "bytemuck",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -1063,6 +1423,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-float"
+version = "3.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1e1c390732d15f1d48471625cd92d154e66db2c56645e29a9cd26f4699f72dc"
+dependencies = [
+ "num-traits",
+ "rand",
+ "serde",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1079,6 +1450,51 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pest"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
+dependencies = [
+ "memchr",
+ "thiserror 2.0.12",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d725d9cfd79e87dccc9341a2ef39d1b6f6353d68c4b33c177febbe1a402c97c5"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db7d01726be8ab66ab32f9df467ae8b1148906685bbe75c82d1e65d7f5b3f841"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1149,6 +1565,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1157,6 +1579,7 @@ dependencies = [
  "libc",
  "rand_chacha",
  "rand_core",
+ "serde",
 ]
 
 [[package]]
@@ -1175,7 +1598,17 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
+ "serde",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -1230,7 +1663,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
  "libredox",
  "thiserror 1.0.69",
 ]
@@ -1287,9 +1720,28 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.16",
  "libc",
  "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustix"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+dependencies = [
+ "bitflags 2.9.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
  "windows-sys 0.52.0",
 ]
 
@@ -1376,7 +1828,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1385,10 +1837,22 @@ version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1405,6 +1869,16 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "sized-chunks"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
+dependencies = [
+ "bitmaps",
+ "typenum",
+]
 
 [[package]]
 name = "smallvec"
@@ -1454,6 +1928,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "symbol_table"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f19bffd69fb182e684d14e3c71d04c0ef33d1641ac0b9e81c712c734e83703bc"
+dependencies = [
+ "crossbeam-utils",
+ "foldhash",
+ "hashbrown",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1472,7 +1968,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1490,12 +1986,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "test-log"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f46083d221181166e5b6f6b1e5f1d499f3a76888826e6cb1d057554157cd0f"
 dependencies = [
- "env_logger",
+ "env_logger 0.11.8",
  "test-log-macros",
  "tracing-subscriber",
 ]
@@ -1508,7 +2026,7 @@ checksum = "888d0c3c6db53c0fdab160d2ed5e12ba745383d3e85813f2ea0f2b1475ab553f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1537,7 +2055,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1548,7 +2066,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1580,7 +2098,7 @@ dependencies = [
  "aho-corasick",
  "derive_builder",
  "esaxx-rs",
- "getrandom",
+ "getrandom 0.2.16",
  "hf-hub",
  "indicatif",
  "itertools 0.13.0",
@@ -1651,6 +2169,18 @@ dependencies = [
  "tracing-core",
  "tracing-log",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-ident"
@@ -1768,6 +2298,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1788,7 +2327,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
  "wasm-bindgen-shared",
 ]
 
@@ -1810,7 +2349,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2032,6 +2571,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.9.0",
+]
+
+[[package]]
 name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2063,7 +2611,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
  "synstructure",
 ]
 
@@ -2084,7 +2632,7 @@ checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2104,7 +2652,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
  "synstructure",
 ]
 
@@ -2133,5 +2681,5 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,10 @@ license = "MIT"
 repository = "https://github.com/hellas-ai/catgrad"
 documentation = "https://docs.rs/catgrad"
 
+[features]
+default = ["egglog"]
+egglog = ["dep:egglog"]
+
 [dependencies]
 open-hypergraphs = "0.2.1"
 num-traits = "0.2.19"
@@ -16,6 +20,8 @@ half = "2.5.0"
 log = "0.4.27"
 test-log = "0.2.17"
 memmap2 = "0.9.5"
+egglog = { path = "../egglog", optional = true }
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 clap = { version = "4.5.37", features = ["derive"] }

--- a/src/core/object.rs
+++ b/src/core/object.rs
@@ -7,7 +7,7 @@ pub type Nat = usize;
 // Generating Objects
 
 /// Dtypes supported by N-dimensional arrays.
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
 pub enum Dtype {
     F16,
     F32,
@@ -15,7 +15,7 @@ pub enum Dtype {
 }
 
 /// A rank-N shape is a length-N array of natural numbers
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub struct Shape(pub Vec<Nat>);
 
 impl Shape {

--- a/src/egg_optimizer.rs
+++ b/src/egg_optimizer.rs
@@ -1,0 +1,1245 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex}; // Mutex for global stores if primitives are static
+
+use egglog::{
+    ast::{Literal as EgglogLiteral, Sexp, Symbol as EgglogSymbol},
+    sort::Sort as EgglogSort,
+    EGraph as EgglogEGraph, ExtractReport as EgglogExtractReport,
+    PrimitiveLike as EgglogPrimitiveLike, Value as EgglogValue,
+};
+
+// Catgrad types
+use crate::backend::cpu::ndarray::{
+    NdArray as CatGradNdArray, TaggedNdArray as CatGradTaggedNdArray,
+};
+use crate::core::{
+    Dtype as CatGradDtype,
+    NdArrayType as CatGradNdArrayType,
+    Operation as CatGradOperation,
+    Shape as CatGradShape,
+    Term as CatGradTerm, // This is LaxOpenHypergraph
+    Type as CatGradType, // This is Vec<CatGradNdArrayType>
+};
+use open_hypergraphs::lax::{NodeId as LaxNodeId, OpenHypergraph as LaxOpenHypergraph};
+
+const EGG_PROGRAM_RULES: &str = r#"
+(sort ShapeId)      ;; Opaque ID for CatGradShape
+(sort DTypeId)      ;; Opaque ID for CatGradDtype
+(sort TensorDataId) ;; Opaque ID for CatGradTaggedNdArray (constant data)
+
+(datatype CatGradNode
+    (Input String ShapeId DTypeId)
+    (Param String ShapeId DTypeId)
+    (Const TensorDataId ShapeId DTypeId)
+    (MatrixMultiply CatGradNode CatGradNode) ;; FIXME: generalize to match catgrad
+    (Const F32)
+    (Max CatGradNode)
+    (Sum CatGradNode)
+    (Broadcast CatGradNode ShapeId) ;; broadcast a value to one of shape n+x
+    (Reshape CatGradNode)
+    (Transpose CatGradNode usize usize)
+    (Embedding CatGradNode)
+    (Index CatGradNode usize)
+    (Concat CatGradNode usize)
+    (Arange CatGradNode)
+    (Not CatGradNode)
+    (LT CatGradNode CatGradNode) ;; Less than
+    (EQ CatGradNode CatGradNode) ;; Equality
+    (Sin CatGradNode)
+    (Cos CatGradNode)
+    ;; all the below are pointwise
+    (Copy CatGradNode)
+    (Add CatGradNode CatGradNode)
+    (Sub CatGradNode CatGradNode)
+    (Mul CatGradNode CatGradNode)
+    (Div CatGradNode CatGradNode)
+    (Pow CatGradNode CatGradNode)
+    (Negate CatGradNode)
+)
+
+;; Cost function
+(function cost (CatGradNode) i64
+  :merge (min old new)
+  :default 1000000)
+
+(rule ((= node (Input _ _ _))) ((set (cost node) 0)))
+(rule ((= node (Param _ _ _))) ((set (cost node) 0)))
+(rule ((= node (Const _ _ _))) ((set (cost node) 0)))
+
+;; Primitives (Rust functions)
+(primitive get_node_shape (CatGradNode) ShapeId)
+(primitive get_node_dtype (CatGradNode) DTypeId)
+(primitive get_node_tensor_data (CatGradNode) TensorDataId) ;; Only for (Const ...) nodes
+
+(primitive is_zero_tensor (TensorDataId) ()) ;; Succeeds if tensor data is all zeros
+(primitive is_one_tensor (TensorDataId) ())  ;; Succeeds if tensor data is all ones
+
+(primitive eval_const_add (TensorDataId TensorDataId ShapeId DTypeId) TensorDataId)
+(primitive eval_const_mul (TensorDataId TensorDataId ShapeId DTypeId) TensorDataId)
+
+(primitive get_add_op_cost (ShapeId ShapeId) i64)
+(primitive get_mul_op_cost (ShapeId ShapeId) i64)
+
+
+(rule ((= node (Add lhs rhs))
+       (= c_lhs (cost lhs))
+       (= c_rhs (cost rhs))
+       (= s_lhs (get_node_shape lhs))
+       (= s_rhs (get_node_shape rhs))
+       (= op_cost (get_add_op_cost s_lhs s_rhs)))
+      ((set (cost node) (+ c_lhs c_rhs op_cost))))
+
+(rule ((= node (Mul lhs rhs))
+       (= c_lhs (cost lhs))
+       (= c_rhs (cost rhs))
+       (= s_lhs (get_node_shape lhs))
+       (= s_rhs (get_node_shape rhs))
+       (= op_cost (get_mul_op_cost s_lhs s_rhs)))
+      ((set (cost node) (+ c_lhs c_rhs op_cost))))
+
+;; Rewrite Rules
+;; x + 0 = x
+(rule ((= term (Add lhs (Const zero_data s_zero dt_zero)))
+       (is_zero_tensor zero_data)
+       (= s_lhs (get_node_shape lhs))
+       (= dt_lhs (get_node_dtype lhs))
+       ;; Assuming shapes and dtypes must exactly match for this specific 0-identity
+       ;; For a real system, shape/dtype compatibility would be more nuanced.
+       (= s_lhs s_zero)
+       (= dt_lhs dt_zero))
+      ((union term lhs)))
+
+(rule ((= term (Add (Const zero_data s_zero dt_zero) rhs))
+       (is_zero_tensor zero_data)
+       (= s_rhs (get_node_shape rhs))
+       (= dt_rhs (get_node_dtype rhs))
+       (= s_rhs s_zero)
+       (= dt_rhs dt_zero))
+      ((union term rhs)))
+
+;; x * 1 = x
+(rule ((= term (Mul lhs (Const one_data s_one dt_one)))
+       (is_one_tensor one_data)
+       (= s_lhs (get_node_shape lhs))
+       (= dt_lhs (get_node_dtype lhs))
+       (= s_lhs s_one)
+       (= dt_lhs dt_one))
+      ((union term lhs)))
+
+(rule ((= term (Mul (Const one_data s_one dt_one) rhs))
+       (is_one_tensor one_data)
+       (= s_rhs (get_node_shape rhs))
+       (= dt_rhs (get_node_dtype rhs))
+       (= s_rhs s_one)
+       (= dt_rhs dt_one))
+      ((union term rhs)))
+
+;; Constant Folding: const1 + const2
+(rewrite (Add (Const d1 s dt) (Const d2 s dt))
+         (Const (eval_const_add d1 d2 s dt) s dt))
+
+;; Constant Folding: const1 * const2
+(rewrite (Mul (Const d1 s dt) (Const d2 s dt))
+         (Const (eval_const_mul d1 d2 s dt) s dt))
+"#;
+
+// --- Stores for CatGrad objects and their Egglog IDs ---
+// These need to be accessible by the primitives. Using Mutex for global-like access.
+// A better approach for a real system would be to pass a context Rc<RefCell<Stores>>
+// to the EGraph or have primitives capture it.
+lazy_static::lazy_static! {
+    static ref SHAPE_STORE: Mutex<ShapeStore> = Mutex::new(ShapeStore::default());
+    static ref DTYPE_STORE: Mutex<DtypeStore> = Mutex::new(DtypeStore::default());
+    static ref TENSOR_DATA_STORE: Mutex<TensorDataStore> = Mutex::new(TensorDataStore::default());
+}
+
+#[derive(Clone, Default)]
+struct ShapeStore {
+    shapes: Vec<CatGradShape>,
+    id_to_idx: HashMap<String, usize>,
+    // For quick reverse lookup if a shape already exists, to reuse IDs.
+    // CatGradShape needs to be Hash + Eq for this.
+    shape_to_idx: HashMap<CatGradShape, usize>,
+    next_id_val: usize,
+}
+
+impl ShapeStore {
+    fn assign_id(&mut self, shape: CatGradShape) -> String {
+        if let Some(idx) = self.shape_to_idx.get(&shape) {
+            return format!("s{}", idx);
+        }
+        let idx = self.shapes.len();
+        let id = format!("s{}", idx);
+        self.shapes.push(shape.clone());
+        self.id_to_idx.insert(id.clone(), idx);
+        self.shape_to_idx.insert(shape, idx);
+        id
+    }
+    fn get_shape(&self, id_str: &str) -> Option<&CatGradShape> {
+        self.id_to_idx
+            .get(id_str)
+            .and_then(|idx| self.shapes.get(*idx))
+    }
+}
+
+#[derive(Clone, Default)]
+struct DtypeStore {
+    dtypes: Vec<CatGradDtype>,
+    id_to_idx: HashMap<String, usize>,
+    dtype_to_idx: HashMap<CatGradDtype, usize>, // CatGradDtype is Copy, Eq, Hash
+}
+impl DtypeStore {
+    fn assign_id(&mut self, dtype: CatGradDtype) -> String {
+        if let Some(idx) = self.dtype_to_idx.get(&dtype) {
+            return format!("dt{}", idx);
+        }
+        let idx = self.dtypes.len();
+        let id = format!("dt{}", idx);
+        self.dtypes.push(dtype);
+        self.id_to_idx.insert(id.clone(), idx);
+        self.dtype_to_idx.insert(dtype, idx);
+        id
+    }
+    fn get_dtype(&self, id_str: &str) -> Option<&CatGradDtype> {
+        self.id_to_idx
+            .get(id_str)
+            .and_then(|idx| self.dtypes.get(*idx))
+    }
+}
+
+#[derive(Clone, Default)]
+struct TensorDataStore {
+    tensor_data_vec: Vec<CatGradTaggedNdArray>,
+    id_to_idx: HashMap<String, usize>,
+    // No easy way to hash CatGradTaggedNdArray for reverse lookup to reuse IDs for identical constants
+    // For prototype, always assign a new ID.
+    // A real system might hash the data bytes.
+}
+
+impl TensorDataStore {
+    fn assign_id(&mut self, data: CatGradTaggedNdArray) -> String {
+        let idx = self.tensor_data_vec.len();
+        let id = format!("td{}", idx);
+        self.tensor_data_vec.push(data);
+        self.id_to_idx.insert(id.clone(), idx);
+        id
+    }
+    fn get_data(&self, id_str: &str) -> Option<&CatGradTaggedNdArray> {
+        self.id_to_idx
+            .get(id_str)
+            .and_then(|idx| self.tensor_data_vec.get(*idx))
+    }
+}
+
+// --- CatGrad Term to Egglog S-expression Converter ---
+struct CatGradToEgglogConverter {
+    // These are local to one conversion pass
+    wire_to_egglog_var: HashMap<usize, String>, // LaxNodeId.0 to egglog var name
+    s_expressions: Vec<String>,
+    fresh_var_counter: usize,
+    // To collect (Input ...) and (Param ...) for top-level definition
+    top_level_defines: HashMap<String, String>, // egglog_var_name -> s_expression_string
+}
+
+impl CatGradToEgglogConverter {
+    fn new() -> Self {
+        Self {
+            wire_to_egglog_var: HashMap::new(),
+            s_expressions: Vec::new(),
+            fresh_var_counter: 0,
+            top_level_defines: HashMap::new(),
+        }
+    }
+
+    fn fresh_egglog_var(&mut self, prefix: &str) -> String {
+        let name = format!("_{}_{}", prefix, self.fresh_var_counter);
+        self.fresh_var_counter += 1;
+        name
+    }
+
+    fn translate_wire_to_egglog_var(
+        &mut self,
+        wire_id: LaxNodeId,
+        term: &LaxOpenHypergraph<CatGradNdArrayType, CatGradOperation>,
+        processed_ops: &mut HashMap<usize, Vec<String>>, // EdgeId.0 -> output egglog_vars
+    ) -> Result<String, String> {
+        let wire_idx = wire_id.0;
+        if let Some(egglog_var) = self.wire_to_egglog_var.get(&wire_idx) {
+            return Ok(egglog_var.clone());
+        }
+
+        // Is this wire a graph input?
+        if let Some(input_idx) = term
+            .sources
+            .iter()
+            .position(|&src_wire| src_wire == wire_id)
+        {
+            let egglog_var = self.fresh_egglog_var("input");
+            let node_label = &term.hypergraph.nodes[wire_idx]; // This is CatGradNdArrayType
+            let shape_id = SHAPE_STORE
+                .lock()
+                .unwrap()
+                .assign_id(node_label.shape.clone());
+            let dtype_id = DTYPE_STORE.lock().unwrap().assign_id(node_label.dtype);
+            let input_op_name = format!("graph_input_{}", input_idx); // Or use a lookup for actual names if available
+
+            let sexp_str = format!("(Input \"{}\" {} {})", input_op_name, shape_id, dtype_id);
+            self.top_level_defines
+                .entry(egglog_var.clone())
+                .or_insert(sexp_str);
+            self.wire_to_egglog_var.insert(wire_idx, egglog_var.clone());
+            return Ok(egglog_var);
+        }
+
+        // Find the operation (edge) that produces this wire_id
+        for (edge_idx, hyperedge) in term.hypergraph.adjacency.iter().enumerate() {
+            if let Some(output_port_idx) = hyperedge
+                .targets
+                .iter()
+                .position(|&target_wire| target_wire == wire_id)
+            {
+                // This edge produces our wire. Ensure this edge is processed.
+                let output_egglog_vars = self.process_catgrad_op(edge_idx, term, processed_ops)?;
+                return Ok(output_egglog_vars[output_port_idx].clone());
+            }
+        }
+        Err(format!(
+            "Wire ID {} is not a graph input and not an output of any operation.",
+            wire_idx
+        ))
+    }
+
+    fn process_catgrad_op(
+        &mut self,
+        edge_idx: usize,
+        term: &LaxOpenHypergraph<CatGradNdArrayType, CatGradOperation>,
+        processed_ops: &mut HashMap<usize, Vec<String>>, // EdgeId.0 -> output egglog_vars
+    ) -> Result<Vec<String>, String> {
+        if let Some(vars) = processed_ops.get(&edge_idx) {
+            return Ok(vars.clone());
+        }
+
+        let catgrad_op = &term.hypergraph.edges[edge_idx];
+        let hyperedge = &term.hypergraph.adjacency[edge_idx];
+
+        let mut input_egglog_vars = Vec::new();
+        for input_wire_id in &hyperedge.sources {
+            input_egglog_vars.push(self.translate_wire_to_egglog_var(
+                *input_wire_id,
+                term,
+                processed_ops,
+            )?);
+        }
+
+        let (egglog_constructor, mut current_s_exp) = match catgrad_op {
+            CatGradOperation::Const(val_f32) => {
+                // For prototype, handle only F32 consts.
+                // A real version would use CatGradTaggedNdArray and the TensorDataStore.
+                // Here, we'll make a fake TensorDataId from the float value for simplicity.
+                // Assume shape and dtype are known or can be inferred for constants.
+                // For the prototype, we might need to hardcode or simplify this.
+                // Let's assume a constant implies a scalar F32 for now.
+                let scalar_shape = CatGradShape(vec![]);
+                let f32_dtype = CatGradDtype::F32;
+                let shape_id = SHAPE_STORE.lock().unwrap().assign_id(scalar_shape);
+                let dtype_id = DTYPE_STORE.lock().unwrap().assign_id(f32_dtype);
+
+                // Create a dummy TaggedNdArray for the store
+                let ndarray = CatGradNdArray::new(vec![*val_f32], CatGradShape(vec![]));
+                let data_id = TENSOR_DATA_STORE
+                    .lock()
+                    .unwrap()
+                    .assign_id(CatGradTaggedNdArray::F32(ndarray));
+
+                (
+                    "Const".to_string(),
+                    format!("({} {} {})", data_id, shape_id, dtype_id),
+                )
+            }
+            CatGradOperation::Parameter(name) => {
+                // Assume parameter shape/dtype are known from the output wire's label
+                // This is a simplification. In reality, ParamOps are leaves.
+                let output_wire_label = &term.hypergraph.nodes[hyperedge.targets[0].0];
+                let shape_id = SHAPE_STORE
+                    .lock()
+                    .unwrap()
+                    .assign_id(output_wire_label.shape.clone());
+                let dtype_id = DTYPE_STORE
+                    .lock()
+                    .unwrap()
+                    .assign_id(output_wire_label.dtype);
+                let sexp_str = format!("(Param \"{}\" {} {})", name, shape_id, dtype_id);
+                // Param is a leaf, define it at top level
+                let egglog_var =
+                    self.fresh_egglog_var(&format!("param_{}", name.replace(".", "_")));
+                self.top_level_defines
+                    .entry(egglog_var.clone())
+                    .or_insert(sexp_str);
+
+                // Special handling: process_catgrad_op should return the var directly defined
+                processed_ops.insert(edge_idx, vec![egglog_var.clone()]);
+                return Ok(vec![egglog_var]);
+            }
+            CatGradOperation::Add => (
+                "Add".to_string(),
+                format!("(Add {} {})", input_egglog_vars[0], input_egglog_vars[1]),
+            ),
+            CatGradOperation::Mul => (
+                "Mul".to_string(),
+                format!("(Mul {} {})", input_egglog_vars[0], input_egglog_vars[1]),
+            ),
+            // TODO: Map other CatGradOperations
+            _ => {
+                return Err(format!(
+                    "Unsupported CatGradOperation for egglog translation: {:?}",
+                    catgrad_op
+                ))
+            }
+        };
+
+        // For non-leaf ops, define their outputs
+        let mut output_vars = vec![];
+        for (i, output_wire_id) in hyperedge.targets.iter().enumerate() {
+            let output_egglog_var = self.fresh_egglog_var(&format!(
+                "{}_op{}_out{}",
+                egglog_constructor.to_lowercase(),
+                edge_idx,
+                i
+            ));
+            self.s_expressions
+                .push(format!("(define {} {})", output_egglog_var, current_s_exp));
+            self.wire_to_egglog_var
+                .insert(output_wire_id.0, output_egglog_var.clone());
+            output_vars.push(output_egglog_var);
+        }
+
+        processed_ops.insert(edge_idx, output_vars.clone());
+        Ok(output_vars)
+    }
+
+    pub fn convert(
+        mut self,
+        catgrad_term: &LaxOpenHypergraph<CatGradNdArrayType, CatGradOperation>,
+        output_wires: &[LaxNodeId], // The specific output wires of the graph we care about
+    ) -> Result<String, String> {
+        let mut program_parts = vec![EGG_PROGRAM_RULES.to_string()];
+        let mut processed_ops = HashMap::new();
+
+        let mut final_output_egglog_vars = Vec::new();
+        for output_wire_id in output_wires {
+            let egglog_var = self.translate_wire_to_egglog_var(
+                *output_wire_id,
+                catgrad_term,
+                &mut processed_ops,
+            )?;
+            final_output_egglog_vars.push(egglog_var);
+        }
+
+        // Add top-level defines (Inputs, Params)
+        for (var_name, sexp_str) in self.top_level_defines {
+            program_parts.push(format!("(define {} {})", var_name, sexp_str));
+        }
+
+        program_parts.extend(self.s_expressions);
+
+        // Add extraction command for the final output(s)
+        // For prototype, assume single output for simplicity
+        if final_output_egglog_vars.len() == 1 {
+            program_parts.push(format!("(extract {})", final_output_egglog_vars[0]));
+        } else {
+            // Handle multiple outputs if necessary, e.g., by creating a tuple or extracting one by one
+            return Err(
+                "Multiple outputs not yet fully supported for extraction in prototype".to_string(),
+            );
+        }
+        program_parts.push("(run-schedule (saturate my_rules))".to_string()); // Assume a ruleset `my_rules`
+
+        Ok(program_parts.join("\n"))
+    }
+}
+
+// --- Egglog S-expression to CatGrad Term Converter ---
+struct EgglogToCatGradConverter {
+    shape_store: ShapeStore,
+    dtype_store: DtypeStore,
+    tensor_data_store: TensorDataStore,
+    egglog_var_to_catgrad_wire: HashMap<String, LaxNodeId>,
+    catgrad_term_builder: LaxOpenHypergraph<CatGradNdArrayType, CatGradOperation>,
+    // To handle (let ((_v0 (Input ...))) (_v0)) from egglog extract
+    // This maps let-bound vars to their defining CatGradNode Sexp
+    let_bindings: HashMap<EgglogSymbol, egglog::ast::Sexp>,
+}
+
+#[derive(Debug)]
+enum BuildFromSexpError {
+    Egglog(egglog::ast::ParseError),
+    UnknownVar(String),
+    CatGrad(String),
+    BadInput,
+}
+
+impl From<egglog::ast::ParseError> for BuildFromSexpError {
+    fn from(err: egglog::ast::ParseError) -> Self {
+        BuildFromSexpError::Egglog(err)
+    }
+}
+
+impl From<String> for BuildFromSexpError {
+    fn from(err: String) -> Self {
+        BuildFromSexpError::CatGrad(err)
+    }
+}
+
+impl From<&str> for BuildFromSexpError {
+    fn from(err: &str) -> Self {
+        BuildFromSexpError::CatGrad(err.to_string())
+    }
+}
+
+impl std::fmt::Display for BuildFromSexpError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BuildFromSexpError::Egglog(err) => write!(f, "Egglog parse error: {}", err),
+            BuildFromSexpError::CatGrad(err) => write!(f, "CatGrad conversion error: {}", err),
+            BuildFromSexpError::UnknownVar(var) => write!(f, "Unknown variable: {}", var),
+            BuildFromSexpError::BadInput => write!(f, "Bad input: not enough S-expressions"),
+        }
+    }
+}
+impl std::error::Error for BuildFromSexpError {}
+
+impl EgglogToCatGradConverter {
+    fn new(s_store: ShapeStore, d_store: DtypeStore, td_store: TensorDataStore) -> Self {
+        Self {
+            shape_store: s_store,
+            dtype_store: d_store,
+            tensor_data_store: td_store,
+            egglog_var_to_catgrad_wire: HashMap::new(),
+            catgrad_term_builder: LaxOpenHypergraph::empty(),
+            let_bindings: HashMap::new(),
+        }
+    }
+
+    // Parses egglog's Sexp AST and builds CatGradTerm
+    // Returns the CatGrad NodeId for the output wire of the created operation
+    fn build_from_sexp(
+        &mut self,
+        sexp: &egglog::ast::Sexp,
+    ) -> Result<LaxNodeId, BuildFromSexpError> {
+        match sexp {
+            egglog::ast::Sexp::Atom(sym, _) => {
+                // This is a variable, look it up. If it's let-bound, parse its definition.
+                if let Some(defined_sexp) = self.let_bindings.get(sym).cloned() {
+                    // If already processed this var via let, return its wire
+                    if let Some(wire_id) = self.egglog_var_to_catgrad_wire.get(&sym.to_string()) {
+                        return Ok(*wire_id);
+                    }
+                    // Otherwise, process the definition now
+                    let wire_id = self.build_from_sexp(&defined_sexp)?;
+                    self.egglog_var_to_catgrad_wire
+                        .insert(sym.to_string(), wire_id);
+                    return Ok(wire_id);
+                }
+                // If not let-bound, it must have been defined earlier (e.g. by (define ...))
+                // and should already be in wire_to_egglog_var from the forward pass,
+                // or it's an error.
+                // For parsing extracted term, this direct var usage means it was likely defined via (define)
+                // and should be in wire_to_egglog_var.
+                // However, our CatGradToEgglogConverter creates (define) for *all* nodes.
+                // The (extract) output might simplify this.
+                // If egglog (extract) gives (Input "name" s_id dt_id), this branch is hit.
+                // For now, if it's an atom, assume it's a var that should be in egglog_var_to_catgrad_wire
+                // This part of logic might need refinement based on actual (extract) output.
+                self.egglog_var_to_catgrad_wire
+                    .get(&sym.to_string())
+                    .cloned()
+                    .ok_or_else(|| BuildFromSexpError::UnknownVar(sym.to_string()))
+            }
+            egglog::ast::Sexp::List(items, list_span) => {
+                if items.is_empty() {
+                    return Err(BuildFromSexpError::BadInput);
+                }
+                let head_sexp = &items[0];
+                let args_sexps = &items[1..];
+
+                match head_sexp {
+                    egglog::ast::Sexp::Atom(head_sym, _) => {
+                        let op_name = head_sym.as_str();
+                        match op_name {
+                            "Input" => {
+                                let name = args_sexps[0].expect_string("Input name")?;
+                                let shape_id_str =
+                                    args_sexps[1].expect_atom("ShapeID for Input")?.to_string();
+                                let dtype_id_str =
+                                    args_sexps[2].expect_atom("DTypeID for Input")?.to_string();
+
+                                let shape = self
+                                    .shape_store
+                                    .get_shape(&shape_id_str)
+                                    .ok_or("Invalid ShapeID")?
+                                    .clone();
+                                let dtype = *self
+                                    .dtype_store
+                                    .get_dtype(&dtype_id_str)
+                                    .ok_or("Invalid DTypeID")?;
+
+                                // In CatGrad, an Input is just a wire with a type.
+                                // It doesn't correspond to an "Operation" in the same way.
+                                // We create a new node (wire) in the graph for it.
+                                let node_label = CatGradNdArrayType::new(shape, dtype);
+                                let wire_id =
+                                    self.catgrad_term_builder.hypergraph.new_node(node_label);
+                                // This wire is now a source of the new graph.
+                                self.catgrad_term_builder.sources.push(wire_id);
+                                Ok(wire_id)
+                            }
+                            "Param" => {
+                                let name = args_sexps[0].expect_string("Param name")?;
+                                let shape_id_str =
+                                    args_sexps[1].expect_atom("ShapeID for Param")?.to_string();
+                                let dtype_id_str =
+                                    args_sexps[2].expect_atom("DTypeID for Param")?.to_string();
+
+                                let shape = self
+                                    .shape_store
+                                    .get_shape(&shape_id_str)
+                                    .ok_or("Invalid ShapeID for Param")?
+                                    .clone();
+                                let dtype = *self
+                                    .dtype_store
+                                    .get_dtype(&dtype_id_str)
+                                    .ok_or("Invalid DTypeID for Param")?;
+                                let node_label = CatGradNdArrayType::new(shape, dtype);
+
+                                let cg_op = CatGradOperation::Parameter(name);
+                                let (_edge_id, interface) = self
+                                    .catgrad_term_builder
+                                    .hypergraph
+                                    .new_operation(cg_op, vec![], vec![node_label]);
+                                Ok(interface.1[0]) // Param has one output wire
+                            }
+                            "Const" => {
+                                let data_id_str = args_sexps[0]
+                                    .expect_atom("TensorDataID for Const")?
+                                    .to_string();
+                                let shape_id_str =
+                                    args_sexps[1].expect_atom("ShapeID for Const")?.to_string();
+                                let dtype_id_str =
+                                    args_sexps[2].expect_atom("DTypeID for Const")?.to_string();
+
+                                let data = self
+                                    .tensor_data_store
+                                    .get_data(&data_id_str)
+                                    .ok_or("Invalid TensorDataID for Const")?;
+                                let shape = self
+                                    .shape_store
+                                    .get_shape(&shape_id_str)
+                                    .ok_or("Invalid ShapeID for Const")?
+                                    .clone();
+                                let dtype = *self
+                                    .dtype_store
+                                    .get_dtype(&dtype_id_str)
+                                    .ok_or("Invalid DTypeID for Const")?;
+                                let node_label = CatGradNdArrayType::new(shape, dtype);
+
+                                // Extract f32 val for CatGradOperation::Const (prototype limitation)
+                                let val_f32 = match data {
+                                    CatGradTaggedNdArray::F32(nd_arr) => {
+                                        if nd_arr.shape.0.is_empty() && nd_arr.data.len() == 1 {
+                                            nd_arr.data[0]
+                                        } else {
+                                            return Err(BuildFromSexpError::CatGrad(
+                                                "Const data for prototype must be scalar F32"
+                                                    .to_string(),
+                                            ));
+                                        }
+                                    }
+                                    _ => {
+                                        return Err(BuildFromSexpError::CatGrad(
+                                            "Const data for prototype must be F32".to_string(),
+                                        ));
+                                    }
+                                };
+
+                                let cg_op = CatGradOperation::Const(val_f32);
+                                let (_edge_id, interface) = self
+                                    .catgrad_term_builder
+                                    .hypergraph
+                                    .new_operation(cg_op, vec![], vec![node_label]);
+                                Ok(interface.1[0]) // Const has one output wire
+                            }
+                            "Add" | "Mul" => {
+                                let lhs_wire = self.build_from_sexp(&args_sexps[0])?;
+                                let rhs_wire = self.build_from_sexp(&args_sexps[1])?;
+
+                                let lhs_label =
+                                    self.catgrad_term_builder.hypergraph.nodes[lhs_wire.0].clone();
+                                // TODO: Check compatibility or derive output type properly
+                                let output_label = lhs_label.clone();
+
+                                let cg_op = if op_name == "Add" {
+                                    CatGradOperation::Add
+                                } else {
+                                    CatGradOperation::Mul
+                                };
+                                let (_edge_id, interface) =
+                                    self.catgrad_term_builder.hypergraph.new_operation(
+                                        cg_op,
+                                        vec![lhs_label, output_label.clone()],
+                                        vec![output_label],
+                                    );
+                                self.catgrad_term_builder
+                                    .hypergraph
+                                    .unify(interface.0[0], lhs_wire);
+                                self.catgrad_term_builder
+                                    .hypergraph
+                                    .unify(interface.0[1], rhs_wire);
+                                Ok(interface.1[0])
+                            }
+                            "let" => {
+                                // (let ((var1 def1) (var2 def2) ...) body_expr)
+                                if let Sexp::List(bindings, _) = &args_sexps[0] {
+                                    let mut new_bindings = self.let_bindings.clone();
+                                    for binding_sexp in bindings {
+                                        if let Sexp::List(pair, _) = binding_sexp {
+                                            if pair.len() == 2 {
+                                                if let Sexp::Atom(var_sym, _) = &pair[0] {
+                                                    new_bindings.insert(*var_sym, pair[1].clone());
+                                                } else {
+                                                    return Err("Let binding var not atom".into());
+                                                }
+                                            } else {
+                                                return Err("Let binding not a pair".into());
+                                            }
+                                        } else {
+                                            return Err("Let binding not a list".into());
+                                        }
+                                    }
+                                    // Process body with these bindings
+                                    let mut sub_converter = EgglogToCatGradConverter {
+                                        shape_store: self.shape_store.clone(),
+                                        dtype_store: self.dtype_store.clone(),
+                                        tensor_data_store: self.tensor_data_store.clone(),
+                                        egglog_var_to_catgrad_wire: self
+                                            .egglog_var_to_catgrad_wire
+                                            .clone(),
+                                        catgrad_term_builder: LaxOpenHypergraph::empty(), // build sub-graph
+                                        let_bindings: new_bindings,
+                                    };
+                                    let body_wire =
+                                        sub_converter.build_from_sexp(&args_sexps[1])?;
+                                    // Now merge sub_converter's term_builder into self.catgrad_term_builder
+                                    // This is complex: involves remapping NodeIds, etc.
+                                    // For prototype, (let) might be tricky if extract doesn't inline everything.
+                                    // Assuming extract produces a tree or DAG without new lets for now.
+                                    // If extract produces lets, we need to handle them properly.
+                                    // This simplistic handling assumes the let-bound vars are used in the body
+                                    // and their corresponding CatGrad wires will be created.
+                                    self.catgrad_term_builder.hypergraph.coproduct_assign(
+                                        sub_converter.catgrad_term_builder.hypergraph,
+                                    );
+                                    // The body_wire is relative to sub_converter. Needs remapping.
+                                    // This is a placeholder, real merging is harder.
+                                    self.egglog_var_to_catgrad_wire
+                                        .extend(sub_converter.egglog_var_to_catgrad_wire);
+                                    return Ok(body_wire); // This wire ID might be from a different graph if not careful
+                                }
+                                Err("Invalid let structure".into())
+                            }
+                            _ => Err(format!(
+                                "Unsupported egglog constructor in output: {}",
+                                op_name
+                            )
+                            .into()),
+                        }
+                    }
+                    _ => Err("Egglog output head is not an atom".into()),
+                }
+            }
+            _ => Err("Egglog output is not a list or atom".into()),
+        }
+    }
+
+    pub fn convert(
+        mut self,
+        extracted_sexp_str: &str,
+        // Original catgrad term's output types, to set for the new term
+        original_output_types: CatGradType,
+    ) -> Result<CatGradTerm, BuildFromSexpError> {
+        let sexps_vec = egglog::ast::all_sexps(egglog::ast::Context::new(None, extracted_sexp_str))
+            .map_err(|e| e.to_string())?;
+        if sexps_vec.is_empty() {
+            return Err("Empty extraction result from egglog".into());
+        }
+        let root_sexp = &sexps_vec[0]; // Assume extract gives one top-level term expression
+
+        let final_output_wire = self.build_from_sexp(root_sexp)?;
+        self.catgrad_term_builder.targets = vec![final_output_wire];
+
+        // Ensure output wire types match the original
+        // This is simplified. A real system would verify or adjust.
+        if self.catgrad_term_builder.targets.len() == original_output_types.len() {
+            for (i, target_wire_id) in self.catgrad_term_builder.targets.iter().enumerate() {
+                self.catgrad_term_builder.hypergraph.nodes[target_wire_id.0] =
+                    original_output_types[i].clone();
+            }
+        } else {
+            // Mismatch in number of outputs, could be an error or require complex handling
+            return Err(format!(
+                "Output arity mismatch: expected {}, got {}",
+                original_output_types.len(),
+                self.catgrad_term_builder.targets.len()
+            )
+            .into());
+        }
+
+        // The builder now contains the new CatGradTerm
+        // The quotient map might need to be applied if `build_from_sexp` didn't handle all sharing correctly.
+        // For now, assume build_from_sexp tries to build a minimal graph.
+        self.catgrad_term_builder.hypergraph.quotient();
+
+        Ok(self.catgrad_term_builder)
+    }
+}
+
+/// Main public function for optimization
+pub fn optimize_with_egglog(
+    catgrad_term: &CatGradTerm,
+    output_wires_indices: &[usize], // Indices into catgrad_term.targets
+) -> Result<CatGradTerm, String> {
+    // 1. Clear global stores for a fresh run (or manage them per call if not global)
+    SHAPE_STORE.lock().unwrap().shapes.clear();
+    SHAPE_STORE.lock().unwrap().id_to_idx.clear();
+    SHAPE_STORE.lock().unwrap().shape_to_idx.clear();
+    SHAPE_STORE.lock().unwrap().next_id_val = 0;
+    DTYPE_STORE.lock().unwrap().dtypes.clear();
+    DTYPE_STORE.lock().unwrap().id_to_idx.clear();
+    DTYPE_STORE.lock().unwrap().dtype_to_idx.clear();
+    TENSOR_DATA_STORE.lock().unwrap().tensor_data_vec.clear();
+    TENSOR_DATA_STORE.lock().unwrap().id_to_idx.clear();
+
+    // 2. Translate CatGradTerm to egglog s-expression
+    let converter = CatGradToEgglogConverter::new();
+    let original_target_node_ids: Vec<LaxNodeId> = output_wires_indices
+        .iter()
+        .map(|&idx| catgrad_term.targets[idx])
+        .collect();
+
+    let egglog_program_string = converter
+        .convert(catgrad_term, &original_target_node_ids)
+        .map_err(|e| format!("CatGrad to Egglog conversion error: {}", e))?;
+
+    println!("--- Generated Egglog Program ---");
+    println!("{}", egglog_program_string);
+    println!("--------------------------------");
+
+    // 3. Run egglog
+    let mut egraph = EgglogEGraph::default();
+    // Register primitives (this needs more elaborate setup matching egglog's API)
+    register_catgrad_primitives(&mut egraph)?;
+
+    let msgs = egraph
+        .parse_and_run_program(None, &egglog_program_string)
+        .map_err(|e| format!("Egglog execution error: {}", e))?;
+
+    println!("--- Egglog Messages ---");
+    for msg in msgs {
+        println!("{}", msg);
+    }
+    println!("-----------------------");
+
+    // 4. Extract optimized term
+    // The extraction result comes from the last `(extract ...)` command's side effect on `egraph.extract_report`.
+    let extracted_s_expr = match egraph.get_extract_report() {
+        Some(EgglogExtractReport::Best {
+            termdag,
+            cost: _,
+            term,
+        }) => {
+            println!(
+                "Extracted egglog term (cost ...): {} (internal)",
+                termdag.to_string(term)
+            );
+            termdag.to_string(term) // This is what we need to parse back
+        }
+        Some(EgglogExtractReport::Variants { termdag, terms }) => {
+            if terms.is_empty() {
+                return Err("Egglog extraction returned no variants.".to_string());
+            }
+            println!("Extracted egglog variants. Using the first one.");
+            termdag.to_string(&terms[0])
+        }
+        None => return Err("No extraction report from egglog. Did (extract) run?".to_string()),
+    };
+
+    println!("--- Extracted Egglog S-expression ---");
+    println!("{}", extracted_s_expr);
+    println!("-------------------------------------");
+
+    // 5. Translate egglog s-expression back to CatGradTerm
+    let shape_s = SHAPE_STORE.lock().unwrap().clone();
+    let dtype_s = DTYPE_STORE.lock().unwrap().clone();
+    let tensor_s = TENSOR_DATA_STORE.lock().unwrap().clone();
+    let back_converter = EgglogToCatGradConverter::new(shape_s, dtype_s, tensor_s);
+
+    // Collect original output types
+    let original_output_types: CatGradType = original_target_node_ids
+        .iter()
+        .map(|node_id| catgrad_term.hypergraph.nodes[node_id.0].clone())
+        .collect();
+
+    let optimized_catgrad_term = back_converter
+        .convert(&extracted_s_expr, original_output_types)
+        .map_err(|e| format!("Egglog to CatGrad conversion error: {}", e))?;
+
+    Ok(optimized_catgrad_term)
+}
+
+// --- Primitive Implementations ---
+// Helper macro to create EgglogPrimitive wrappers
+macro_rules! make_primitive {
+    ($name:ident, $rust_fn:ident, $arity:expr) => {
+        #[derive(Debug)]
+        struct $name;
+        impl EgglogPrimitiveLike for $name {
+            fn name(&self) -> EgglogSymbol {
+                EgglogSymbol::from(stringify!($name).to_lowercase())
+            }
+            fn get_type_constraints(
+                &self,
+                _span: &egglog::ast::Span,
+            ) -> Box<dyn egglog::constraint::TypeConstraint> {
+                // For prototype, assume any type for args, specific type for output
+                // This needs to be more robust, using egglog::constraint types.
+                // This is a placeholder, proper type constraints are complex.
+                // We'd use SimpleTypeConstraint or AllEqualTypeConstraint from egglog.
+                // For now, let this be dynamically checked or loosely typed.
+                Box::new(egglog::constraint::SimpleTypeConstraint::new(
+                    self.name(),
+                    vec![],                   // This is incorrect, needs actual arg/ret sorts
+                    egglog::ast::Span::Panic, // Placeholder
+                ))
+            }
+            fn apply(
+                &self,
+                values: &[EgglogValue],
+                // sorts: (&[EgglogArcSort], &EgglogArcSort), // Correct signature might involve sorts
+                _typeinfo_sorts: (&[Arc<dyn EgglogSort>], &Arc<dyn EgglogSort>), // Placeholder for actual signature
+                _egraph: Option<&mut EgglogEGraph>,
+            ) -> Option<EgglogValue> {
+                if values.len() != $arity {
+                    // egglog should enforce arity based on (primitive ...) declaration
+                    // but good to double check.
+                    eprintln!(
+                        "Primitive {} called with {} args, expected {}",
+                        stringify!($name),
+                        values.len(),
+                        $arity
+                    );
+                    return None;
+                }
+                $rust_fn(values)
+            }
+        }
+    };
+}
+
+fn get_string_arg(val: &EgglogValue, store_name: &str) -> Result<String, String> {
+    // Egglog Values are u64. Primitives for String, ShapeId etc. will pass Symbols (interned strings) as u64.
+    // We need to convert this back. This assumes Symbol::from(NonZeroU32) then .bits as u64.
+    let bits32 = val.bits as u32;
+    if let Some(nonzero_bits32) = std::num::NonZeroU32::new(bits32) {
+        Ok(EgglogSymbol::from(nonzero_bits32).to_string())
+    } else {
+        Err(format!("Invalid ID format for {} in primitive", store_name))
+    }
+}
+
+// Primitive: (get_node_shape <CatGradNode_val>) -> ShapeId_val
+fn prim_get_node_shape(args: &[EgglogValue]) -> Option<EgglogValue> {
+    // Arg0 is a CatGradNode (represented by its ID in the egraph).
+    // This primitive would need to query the egraph to find what (ShapeId ...) is associated with that node.
+    // This requires egraph access and a way to query attached data, which is complex.
+    // For the prototype, this might be hard to implement fully without deeper egraph interaction.
+    // A simplification: If CatGradNode itself stores its shape_id, we can extract it.
+    // But egglog terms are unified, so we need canonical representative.
+    // Placeholder: return a dummy ShapeId.
+    Some(EgglogValue::from(EgglogSymbol::from(
+        "dummy_shape_id_from_prim",
+    )))
+}
+make_primitive!(GetNodeShapePrim, prim_get_node_shape, 1);
+
+fn prim_get_node_dtype(args: &[EgglogValue]) -> Option<EgglogValue> {
+    Some(EgglogValue::from(EgglogSymbol::from(
+        "dummy_dtype_id_from_prim",
+    )))
+}
+make_primitive!(GetNodeDtypePrim, prim_get_node_dtype, 1);
+
+fn prim_get_node_tensor_data(args: &[EgglogValue]) -> Option<EgglogValue> {
+    Some(EgglogValue::from(EgglogSymbol::from(
+        "dummy_tensor_data_id_from_prim",
+    )))
+}
+make_primitive!(GetNodeTensorDataPrim, prim_get_node_tensor_data, 1);
+
+fn prim_is_zero_tensor(args: &[EgglogValue]) -> Option<EgglogValue> {
+    let data_id_str = get_string_arg(&args[0], "TensorDataId").ok()?;
+    let store = TENSOR_DATA_STORE.lock().unwrap();
+    let data = store.get_data(&data_id_str)?;
+    match data {
+        CatGradTaggedNdArray::F32(arr) => {
+            if arr.data.iter().all(|x| *x == 0.0) {
+                Some(EgglogValue::unit())
+            } else {
+                None
+            }
+        }
+        // Handle other dtypes
+        _ => None,
+    }
+}
+make_primitive!(IsZeroTensorPrim, prim_is_zero_tensor, 1);
+
+fn prim_is_one_tensor(args: &[EgglogValue]) -> Option<EgglogValue> {
+    let data_id_str = get_string_arg(&args[0], "TensorDataId").ok()?;
+    let store = TENSOR_DATA_STORE.lock().unwrap();
+    let data = store.get_data(&data_id_str)?;
+    match data {
+        CatGradTaggedNdArray::F32(arr) => {
+            if arr.data.iter().all(|x| *x == 1.0) {
+                Some(EgglogValue::unit())
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+make_primitive!(IsOneTensorPrim, prim_is_one_tensor, 1);
+
+fn prim_eval_const_add(args: &[EgglogValue]) -> Option<EgglogValue> {
+    let d1_id_str = get_string_arg(&args[0], "TensorDataId1 for Add").ok()?;
+    let d2_id_str = get_string_arg(&args[1], "TensorDataId2 for Add").ok()?;
+    // Shape and DType args are for type checking / ensuring compatibility, not strictly needed for op if data has type info
+    // let _s_id_str = get_string_arg(&args[2], "ShapeId for Add").ok()?;
+    // let _dt_id_str = get_string_arg(&args[3], "DTypeId for Add").ok()?;
+
+    let mut store = TENSOR_DATA_STORE.lock().unwrap();
+    let d1 = store.get_data(&d1_id_str)?.clone(); // Clone to operate
+    let d2 = store.get_data(&d2_id_str)?.clone();
+
+    match (d1, d2) {
+        (CatGradTaggedNdArray::F32(arr1), CatGradTaggedNdArray::F32(arr2)) => {
+            if arr1.shape != arr2.shape {
+                return None;
+            } // Basic check
+            let mut result_data = Vec::with_capacity(arr1.data.len());
+            for (x, y) in arr1.data.iter().zip(arr2.data.iter()) {
+                result_data.push(x + y);
+            }
+            let result_arr = CatGradNdArray::new(result_data, arr1.shape.clone());
+            let new_data_id = store.assign_id(CatGradTaggedNdArray::F32(result_arr));
+            Some(EgglogValue::from(EgglogSymbol::from(new_data_id.as_str())))
+        }
+        _ => None, // Unsupported types for add
+    }
+}
+make_primitive!(EvalConstAddPrim, prim_eval_const_add, 4);
+
+fn prim_eval_const_mul(args: &[EgglogValue]) -> Option<EgglogValue> {
+    let d1_id_str = get_string_arg(&args[0], "TensorDataId1 for Mul").ok()?;
+    let d2_id_str = get_string_arg(&args[1], "TensorDataId2 for Mul").ok()?;
+
+    let mut store = TENSOR_DATA_STORE.lock().unwrap();
+    let d1 = store.get_data(&d1_id_str)?.clone();
+    let d2 = store.get_data(&d2_id_str)?.clone();
+
+    match (d1, d2) {
+        (CatGradTaggedNdArray::F32(arr1), CatGradTaggedNdArray::F32(arr2)) => {
+            if arr1.shape != arr2.shape {
+                return None;
+            }
+            let mut result_data = Vec::with_capacity(arr1.data.len());
+            for (x, y) in arr1.data.iter().zip(arr2.data.iter()) {
+                result_data.push(x * y);
+            }
+            let result_arr = CatGradNdArray::new(result_data, arr1.shape.clone());
+            let new_data_id = store.assign_id(CatGradTaggedNdArray::F32(result_arr));
+            Some(EgglogValue::from(EgglogSymbol::from(new_data_id.as_str())))
+        }
+        _ => None,
+    }
+}
+make_primitive!(EvalConstMulPrim, prim_eval_const_mul, 4);
+
+fn prim_get_add_op_cost(args: &[EgglogValue]) -> Option<EgglogValue> {
+    // Placeholder: actual cost depends on shapes.
+    // Args are ShapeIds.
+    Some(EgglogValue::from(10i64)) // Example cost
+}
+make_primitive!(GetAddOpCostPrim, prim_get_add_op_cost, 2);
+
+fn prim_get_mul_op_cost(args: &[EgglogValue]) -> Option<EgglogValue> {
+    Some(EgglogValue::from(10i64))
+}
+make_primitive!(GetMulOpCostPrim, prim_get_mul_op_cost, 2);
+
+fn register_catgrad_primitives(egraph: &mut EgglogEGraph) -> Result<(), String> {
+    // This registration mechanism depends on egglog's exact API.
+    // egglog::EGraph::add_primitive takes `impl Into<Primitive>`
+    // The make_primitive macro defines structs that impl PrimitiveLike.
+    // We need to ensure they are correctly wrapped.
+    egraph.add_primitive(GetNodeShapePrim);
+    egraph.add_primitive(GetNodeDtypePrim);
+    egraph.add_primitive(GetNodeTensorDataPrim);
+    egraph.add_primitive(IsZeroTensorPrim);
+    egraph.add_primitive(IsOneTensorPrim);
+    egraph.add_primitive(EvalConstAddPrim);
+    egraph.add_primitive(EvalConstMulPrim);
+    egraph.add_primitive(GetAddOpCostPrim);
+    egraph.add_primitive(GetMulOpCostPrim);
+    Ok(())
+}
+
+// Helper for Sexp parsing (simplified for prototype)
+// Real parsing should use egglog's parser or a proper Sexp library.
+trait SexpExt {
+    fn expect_atom(&self, context: &str) -> Result<EgglogSymbol, String>;
+    fn expect_string(&self, context: &str) -> Result<String, String>;
+}
+
+impl SexpExt for egglog::ast::Sexp {
+    fn expect_atom(&self, context: &str) -> Result<EgglogSymbol, String> {
+        if let egglog::ast::Sexp::Atom(s, _) = self {
+            Ok(*s)
+        } else {
+            Err(format!(
+                "Expected atom for {} but got (something else?)",
+                context
+            ))
+        }
+    }
+    fn expect_string(&self, context: &str) -> Result<String, String> {
+        if let egglog::ast::Sexp::Literal(EgglogLiteral::String(s), _) = self {
+            Ok(s.to_string())
+        } else {
+            Err(format!(
+                "Expected string literal for {} but got (something else?)",
+                context
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::{Dtype, NdArrayType, Operation, Shape};
+    use open_hypergraphs::lax::Hyperedge;
+
+    #[test]
+    fn test_prototype_optimization_add_zero() {
+        // Build a simple CatGradTerm: input + 0
+        let mut term = LaxOpenHypergraph::<NdArrayType, Operation>::empty();
+
+        let shape = Shape(vec![2, 2]);
+        let dtype = Dtype::F32;
+        let nd_type = NdArrayType::new(shape.clone(), dtype);
+
+        // Input wire
+        let input_wire = term.hypergraph.new_node(nd_type.clone());
+        term.sources.push(input_wire);
+
+        // Const 0 wire
+        // let zero_data = NdArray::new(vec![0.0; 4], shape.clone());
+        // let zero_tagged = TaggedNdArray::F32(zero_data);
+        let const_zero_op_node_label = nd_type.clone();
+        let (_const_edge, const_interface) = term.hypergraph.new_operation(
+            Operation::Const(0.0),
+            vec![],
+            vec![const_zero_op_node_label],
+        );
+        let zero_wire = const_interface.1[0];
+
+        // Add operation
+        let add_op_output_node_label = nd_type.clone();
+        let (_add_edge, add_interface) = term.hypergraph.new_operation(
+            Operation::Add,
+            vec![nd_type.clone(), nd_type.clone()],
+            vec![add_op_output_node_label],
+        );
+        // Connect inputs to Add
+        term.hypergraph.unify(add_interface.0[0], input_wire);
+        term.hypergraph.unify(add_interface.0[1], zero_wire);
+
+        let output_wire = add_interface.1[0];
+        term.targets.push(output_wire);
+
+        println!("Original CatGrad Term (structure):");
+        // A simple way to inspect, not a full print
+        println!("  Sources: {:?}", term.sources);
+        println!("  Targets: {:?}", term.targets);
+        println!(
+            "  Nodes: {} (labels omitted for brevity)",
+            term.hypergraph.nodes.len()
+        );
+        println!(
+            "  Edges: {} (ops: {:?})",
+            term.hypergraph.edges.len(),
+            term.hypergraph.edges
+        );
+        for (i, adj) in term.hypergraph.adjacency.iter().enumerate() {
+            println!("    Edge {}: {:?} -> {:?}", i, adj.sources, adj.targets);
+        }
+
+        match optimize_with_egglog(&term, &[0]) {
+            Ok(optimized_term) => {
+                println!("\nOptimized CatGrad Term (structure):");
+                println!("  Sources: {:?}", optimized_term.sources);
+                println!("  Targets: {:?}", optimized_term.targets);
+                println!("  Nodes: {}", optimized_term.hypergraph.nodes.len());
+                println!(
+                    "  Edges: {} (ops: {:?})",
+                    optimized_term.hypergraph.edges.len(),
+                    optimized_term.hypergraph.edges
+                );
+                for (i, adj) in optimized_term.hypergraph.adjacency.iter().enumerate() {
+                    println!("    Edge {}: {:?} -> {:?}", i, adj.sources, adj.targets);
+                }
+
+                // Expected: graph simplifies to just the input wire
+                // - Sources should still contain the original input wire (or its equivalent after re-numbering)
+                // - Targets should point to that same input wire.
+                // - Number of operations (edges) should be 0.
+                // - Number of nodes might be 1 (just the input wire).
+                assert_eq!(
+                    optimized_term.hypergraph.edges.len(),
+                    0,
+                    "Optimized graph should have no operations for input + 0"
+                );
+                assert_eq!(
+                    optimized_term.hypergraph.nodes.len(),
+                    1,
+                    "Optimized graph should have one node (the input)"
+                );
+                assert_eq!(
+                    optimized_term.sources.len(),
+                    1,
+                    "Optimized graph should have one source"
+                );
+                assert_eq!(
+                    optimized_term.targets.len(),
+                    1,
+                    "Optimized graph should have one target"
+                );
+                assert_eq!(
+                    optimized_term.sources[0], optimized_term.targets[0],
+                    "Output should be the input wire"
+                );
+            }
+            Err(e) => panic!("Optimization failed: {}", e),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,4 @@
 pub mod backend;
 pub mod core;
+#[cfg(feature = "egglog")]
+pub mod egg_optimizer;


### PR DESCRIPTION

**Abstract:**

This RFC proposes the integration of `egglog`, a fixpoint reasoning system unifying Datalog and Equality Saturation (EqSat), into the `catgrad` deep learning compiler. The primary goal is to leverage `egglog` for optimizing `catgrad`'s computation graphs (represented as `open-hypergraph` terms) and potentially for performing advanced static analyses. We will focus on translating `catgrad` terms into `egglog`'s representation, defining rewrite rules for common optimizations, and translating optimized `egglog` terms back into the `catgrad` ecosystem.

**1. Motivation:**

`catgrad` currently builds computation graphs using `open-hypergraph`. While this provides a flexible and powerful representation, implementing complex graph optimizations (e.g., operator fusion, algebraic simplifications with semantic conditions, layout optimization) directly on this structure can be challenging and error-prone.

`egglog` offers several compelling advantages:
*   **Unified Datalog and EqSat:** It combines the relational power of Datalog for expressing analyses with the term rewriting power of Equality Saturation for optimization.
*   **Efficient Equational Reasoning:** Built-in unification and congruence closure allow for efficient manipulation of equivalent terms.
*   **Semantic Analysis for Rewrites:** `egglog` allows Datalog-style rules to derive semantic information (e.g., shapes, costs, data properties) which can then conditionally gate rewrite rules. This is crucial for sound and effective optimizations, as highlighted by the `egglog` paper (e.g., the Herbie case study).
*   **Extensible Language:** Custom sorts, datatypes, functions, and merge behaviors allow tailoring `egglog` to specific domains like `catgrad`.
*   **Declarative Optimizations:** Rewrite rules are declarative, potentially making the optimization pass easier to develop, maintain, and verify compared to imperative graph transformations.

By integrating `egglog`, we aim to:
*   Implement a wider range of optimizations for `catgrad` graphs.
*   Simplify the development of new optimization passes.
*   Enable more sophisticated analyses to guide optimizations.
*   Potentially discover novel, non-obvious optimizations through equality saturation.

**2. Proposed Solution:**

We propose using `egglog` as an optimization and analysis engine for `catgrad` terms. The general workflow will be:

1.  **Translate `catgrad` Term to `egglog`:** Convert a `catgrad::core::operation::Term` (an `open-hypergraph`) into an `egglog` s-expression representing the computation graph.
2.  **Define `egglog` Logic:** Create `egglog` datatypes for `catgrad` operations, sorts for metadata (shapes, dtypes), rewrite rules for optimizations, and functions/relations for analyses.
3.  **Run `egglog`:** Execute the `egglog` program to perform equality saturation, applying rewrite rules and analyses until a fixpoint (or a specified iteration limit).
4.  **Extract Optimized Term:** Use `egglog`'s extraction mechanism to select an "optimal" term from the resulting e-graph based on a cost model.
5.  **Translate `egglog` Term back to `catgrad`:** Convert the optimized `egglog` s-expression back into a `catgrad::core::operation::Term`.

**2.1. Representing `catgrad` Terms in `egglog`:**

We will define `egglog` datatypes to represent the core components of `catgrad` computation graphs.

*   **Metadata Sorts:**
    *   `(sort Shape)`: An opaque sort representing the shape of a tensor. Actual shape information (dimensions, etc.) will be managed by Rust glue code and queried via `egglog` primitives.
    *   `(sort DType)`: An opaque sort representing the data type of a tensor.
    *   `(sort TensorData)`: An opaque sort representing the actual data of a constant tensor, allowing `egglog` to reason about constant folding without embedding large tensors directly.

*   **Main Term Datatype:**
    ```egglog
    (datatype CatGradNode
      ;; Leaf-like nodes representing data sources
      (Input String Shape DType)      ;; Graph input wire/variable by name
      (Param String Shape DType)      ;; Learnable parameter by name
      (Const TensorData Shape DType)  ;; Constant tensor data (ID to actual data)

      ;; Unary Ops
      (Negate CatGradNode)
      (Exp CatGradNode)
      ;; (Log CatGradNode) ;; Add as needed
      (Sqrt CatGradNode)
      (Sin CatGradNode)
      (Cos CatGradNode)
      (Tanh CatGradNode)
      (Gelu CatGradNode)
      (Softmax CatGradNode)
      (RMSNorm CatGradNode CatGradNode f64) ;; input_term, gamma_param_term, epsilon
      (LayerNorm CatGradNode CatGradNode CatGradNode f64) ;; input_term, gamma_param_term, beta_param_term, epsilon

      ;; Binary Ops
      (Add CatGradNode CatGradNode)
      (Sub CatGradNode CatGradNode)
      (Mul CatGradNode CatGradNode)
      (Div CatGradNode CatGradNode)
      ;; (Pow CatGradNode CatGradNode) ;; Add as needed
      (MatMul CatGradNode CatGradNode) ;; lhs, rhs

      ;; Other Ops
      (Embedding CatGradNode CatGradNode) ;; indices_term, weights_param_term
      (Reshape CatGradNode Shape)         ;; term_to_reshape, target_shape_id
      (Transpose CatGradNode i64 i64)   ;; term_to_transpose, dim0, dim1
      (Linear CatGradNode CatGradNode CatGradNode) ;; input_term, weight_param_term, bias_param_term

      ;; Placeholder for ops not yet modeled or complex ops like Split/Concat
      (UnsupportedOp String CatGradNodeList Shape DType) ;; Name, list of inputs, output shape/dtype
    )

    (datatype CatGradNodeList
        (Cons CatGradNode CatGradNodeList)
        (Nil)
    )
    ```
    *Notes:*
    *   `String` arguments are typically names or identifiers.
    *   `Shape`, `DType`, `TensorData` are opaque IDs. Their properties will be accessed via Rust primitives callable from `egglog`.
    *   Operations like `RMSNorm`, `LayerNorm`, `Linear`, `Embedding` take other `CatGradNode`s as arguments if those arguments are parameters or outputs of other operations.
    *   Variadic inputs (e.g., for a general `Concat`) can be handled using `CatGradNodeList`. Multi-output operations (e.g., `Split`) are more complex; initially, we might treat them as boundaries for `egglog` optimization regions or model their outputs as tuple-like `CatGradNode`s with projection operations. The `UnsupportedOp` can be a temporary catch-all.

**2.2. Mapping `open-hypergraph` to `egglog` Terms:**

The `catgrad::core::operation::Term` (an `open_hypergraph`) will be traversed, likely in topological order (similar to how `EvalState` might process it).
*   Each `catgrad::core::Operation` (a hyperedge in `open-hypergraph`) will be mapped to a constructor of the `CatGradNode` datatype.
*   The inputs to the `catgrad::Operation` (wires in `open-hypergraph`) will become the `CatGradNode` arguments to the corresponding `egglog` constructor.
*   A map from `open_hypergraphs::lax::NodeId` (representing wires/values) to already constructed `egglog::CatGradNode` terms will be maintained during translation to ensure sharing. If a wire is an output of `OpA` and an input to `OpB` and `OpC`, the `egglog` term for `OpA` will be a sub-term in both the `OpB` and `OpC` terms. `egglog`'s e-graph naturally handles this common sub-expression representation.
*   Graph inputs (e.g., placeholders for inference data) will be translated to `(Input name shape dtype)`.
*   Parameters (e.g., model weights) will be translated to `(Param name shape dtype)`.
*   Constant tensors will be translated to `(Const data_id shape dtype)`, where `data_id` is a unique identifier for the tensor data, managed by the Rust glue code.

**2.3. Defining Rewrite Rules in `egglog`:**

We will define various rewrite rules:
*   **Algebraic Simplifications:**
    ```egglog
    (rewrite (Add x (Const (get_zero_tensor_data (get_dtype x)) (get_shape x) (get_dtype x)))
             x)
    (rewrite (Mul x (Const (get_one_tensor_data (get_dtype x)) (get_shape x) (get_dtype x)))
             x)
    ```
    (`get_zero_tensor_data`, `get_one_tensor_data`, `get_shape`, `get_dtype` would be Rust primitives.)

*   **Constant Folding:**
    ```egglog
    ;; Rust primitive: (eval_const_add data_id1 data_id2 shape_id1 shape_id2 dtype_id1 dtype_id2)
    ;;                 -> (new_data_id new_shape_id new_dtype_id) - or just new_data_id if shapes must match.
    ;; For simplicity, assume shapes/dtypes must match for Add.
    (rewrite (Add (Const d1 s dt) (Const d2 s dt))
             (Const (eval_const_add d1 d2 s dt) s dt))
    ```

*   **Operator Fusion (Conceptual):**
    A more complex rule, potentially requiring shape analysis.
    Example: Fusing `MatMul` then `Add` (for bias) into a `Linear` op (if `catgrad` has a fused `Linear`).
    ```egglog
    (rewrite (Add (MatMul X W) B)
             (Linear X W B)
        :when ((is_matmul_add_fusible (get_shape X) (get_shape W) (get_shape B))))
    ```
    (`is_matmul_add_fusible` would be a Rust primitive based on shapes.)

**2.4. Semantic Analyses with `egglog`:**

`egglog`'s Datalog capabilities allow defining analyses that can inform rewrites.
*   **Shape Propagation/Checking:**
    ```egglog
    (relation HasShape (CatGradNode Shape DType))

    (rule ((= node (Input name shape dtype)))
          ((HasShape node shape dtype)))

    (rule ((= node (Add lhs rhs))
           (HasShape lhs shape_lhs dtype_lhs)
           (HasShape rhs shape_rhs dtype_rhs)
           ;; Rust primitive: (check_compatible_add shape_lhs shape_rhs dtype_lhs dtype_rhs)
           ;; This primitive would panic or return false if not compatible.
           ;; If it returns true, it implies output shape/dtype are same as inputs.
           (check_compatible_add shape_lhs shape_rhs dtype_lhs dtype_rhs)))
          ((HasShape node shape_lhs dtype_lhs)))

    ;; Use in a rewrite:
    (rewrite (Add x y) some_optimized_add_pattern
        :when ((HasShape x shape_x _) (HasShape y shape_y _)
               (can_apply_opt_add_pattern shape_x shape_y)))
    ```

*   **Cost Model:**
    A function to estimate the computational cost of a term, used by `egglog` for extraction.
    ```egglog
    (function cost (CatGradNode) i64
      :merge (min old new) ;; If terms are unified, take the min cost
                           ;; If a term's cost is re-derived, take the min
      :default 1_000_000) ;; Default high cost for unhandled ops

    (rule ((= node (Input _ _ _))) ((set (cost node) 0)))
    (rule ((= node (Const _ _ _))) ((set (cost node) 0)))
    (rule ((= node (Param _ _ _))) ((set (cost node) 0))) ;; Params are lookups

    (rule ((= node (Add lhs rhs))
           (= c_lhs (cost lhs))
           (= c_rhs (cost rhs))
           ;; get_add_op_cost is a Rust primitive
           (= c_op (get_add_op_cost (get_shape lhs) (get_shape rhs))))
          ((set (cost node) (+ c_lhs c_rhs c_op))))
    ;; Similar rules for other operations
    ```

**2.5. Workflow and Rust Glue Code:**

*   **Rust to `egglog`:** A Rust function will take a `catgrad::core::operation::Term` (or `catgrad::core::Var` representing the final output) and serialize it into an s-expression string for `egglog`. This involves:
    *   Traversing the `catgrad` graph.
    *   Mapping `catgrad::Operation` enum variants to `egglog::CatGradNode` constructors.
    *   Generating unique string IDs for `Shape`, `DType`, and `TensorData` to pass to `egglog`. The Rust side will maintain the mapping from these IDs to actual Rust `Shape`, `DType` objects and tensor data.
*   **Running `egglog`:** The `egglog::EGraph::parse_and_run_program` method will be used.
*   **`egglog` Primitives:** Rust functions will be registered as `egglog` primitives (e.g., `eval_const_add`, `get_shape_dims`, `is_compatible_for_add`). These functions will operate on the opaque IDs, looking up the actual Rust objects.
*   **`egglog` to Rust:** After extraction, the optimized `egglog` s-expression needs to be parsed back into a `catgrad::core::operation::Term`. This is the reverse of the first step, using the `egglog` term structure to reconstruct the `catgrad` graph.

**3. Prototype Goals (`catgrad/egg-this`):**

The initial prototype will aim to demonstrate the core loop for a small subset of operations and optimizations.
1.  **`egglog` Datatypes:**
    *   Define `(sort Shape)`, `(sort DType)`, `(sort TensorData)`.
    *   Define `(datatype CatGradNode ...)` for:
        *   `Input`, `Param`, `Const`
        *   `Add`, `Mul`
        *   A simple cost function `(function cost (CatGradNode) i64 :merge (min old new))`.
2.  **Rust Glue Code - Serialization:**
    *   Function to convert a simple `catgrad` graph (e.g., `(p0 * input0) + p1`) into the `egglog` s-expression format using the datatypes above.
    *   Manage `Shape`, `DType`, `TensorData` IDs and their mapping to Rust objects.
3.  **Rewrite Rules (in `egg-this`):**
    *   `(rewrite (Add x (Const "zero_id" _ _)) x)`
    *   `(rewrite (Mul x (Const "one_id" _ _)) x)`
    *   Constant folding for `Add` and `Mul`:
        ```egglog
        (primitive eval_const_add_data (TensorData TensorData Shape DType) TensorData)
        (rewrite (Add (Const d1 s dt) (Const d2 s dt))
                 (Const (eval_const_add_data d1 d2 s dt) s dt))
        ```
4.  **Rust Glue Code - Primitives:**
    *   Implement `eval_const_add_data` (Rust function callable from `egglog`). It will take `TensorData` IDs, look up actual tensor data, perform addition, store the new tensor data, and return a new `TensorData` ID.
    *   Implement dummy primitives for `get_shape`, `get_dtype`, `get_zero_tensor_data`, `get_one_tensor_data`.
5.  **Rust Glue Code - Deserialization:**
    *   Function to parse an optimized `egglog::CatGradNode` s-expression back into a `catgrad` graph.
6.  **Test Case:**
    *   Create a simple `catgrad` graph like `(Input "x" ...) + (Const 0 ...)`.
    *   Translate to `egglog`, run `egglog` with the identity rewrite rule.
    *   Translate back and verify the graph is simplified to `(Input "x" ...)`.

**4. Alternative Approaches Considered:**

*   **`egglog` for Sub-Components:** Optimizing only parts of the graph. Considered less holistic for a first pass.
*   **`egglog` as Pure Analysis Engine:** Using Datalog features for graph analysis, results guide Rust transformations. This underutilizes EqSat.
*   **Deep Embedding of Hypergraphs:** Modeling hypergraph connectivity directly in `egglog` relations. More complex and deviates from `egglog`'s term-centric model initially, but could be powerful for graph-level rewrites in the future.

The chosen approach (Alternative A from brainstorming) offers a good balance of leveraging `egglog`'s core strengths for term optimization while being relatively straightforward to conceptualize for an initial integration.

**5. Potential Challenges & Future Work:**

*   **Full `open-hypergraph` to `egglog::Term` Mapping:** Handling all `catgrad::Operation` variants, especially those with complex semantics, variadic inputs, or multiple outputs (e.g., `Split`, `Concat`).
*   **Scalability:** Performance of translation and `egglog` execution on large `catgrad` graphs.
*   **Rule Set Development:** Creating a comprehensive, sound, and effective set of rewrite rules. This will be an ongoing effort.
*   **Cost Model Refinement:** Developing an accurate cost model for `egglog`'s extraction phase is crucial for meaningful optimization.
*   **Integration with `catgrad` Build Process:** How and when to invoke the `egglog` optimization pass.
*   **Debugging:** Debugging `egglog` rules and the interaction between Rust and `egglog` can be complex.
*   **Bidirectional Communication:** Advanced scenarios might involve `egglog` querying Rust for results of non-trivial computations during rewriting (beyond simple primitives).
*   **Proof Generation:** `egglog` might eventually support proof generation, which could be used for verifying optimizations.

**6. Open Questions:**

*   What is the most effective way to represent `Shape`, `DType`, and `TensorData` for `egglog` rules (opaque IDs vs. structured datatypes within `egglog`)? Opaque IDs with Rust primitives seem more flexible initially.
*   How to efficiently manage and query the mapping between `catgrad` objects and `egglog` opaque IDs during the back-and-forth translation?
*   Should `egglog` operate on a "lowered" `catgrad` IR, or directly on the high-level `Operation` representation? Starting with the high-level seems appropriate.
*   How to handle operations that are inherently difficult to model as pure `egglog` terms (e.g., control flow, if it ever exists in `catgrad`, or complex custom kernels)? These might act as boundaries for `egglog` regions.