### PR TITLE
Refactor build methods

### DIFF
--- a/examples/llm/gemma.rs
+++ b/examples/llm/gemma.rs
@@ -1,53 +1,46 @@
 // Gemma-3 model description
 
 use super::{Config, ModelBuilder};
-use catgrad::backend::cpu::eval::{Builder, EvalState};
+use catgrad::backend::cpu::eval::Builder;
 use catgrad::core::nn::layers::*;
 use catgrad::core::{Dtype, NdArrayType, Shape, Var};
 
 pub struct Model;
 
 impl ModelBuilder for Model {
-    fn build(&mut self, batches: usize, tokens: usize, config: &Config) -> EvalState {
-        let in_type = NdArrayType::new(Shape(vec![batches, tokens]), Dtype::I32);
+    fn build(&self, builder: &Builder, config: &Config, x: Var) -> Var {
+        let tokens = x.label.shape.0[1];
+        let emb = Model::embeddings(builder, config, x.clone());
 
-        let state = EvalState::build(|builder| {
-            let x = Var::new(builder.clone(), in_type.clone());
-            let emb = Model::embeddings(builder, config, x.clone());
+        let mut result = emb;
 
-            let mut result = emb;
+        let normalizer = constant(
+            builder,
+            result.label.clone(),
+            (config.hidden_size as f32).sqrt(),
+        );
 
-            let normalizer = constant(
-                builder,
-                result.label.clone(),
-                (config.hidden_size as f32).sqrt(),
-            );
+        result = result * normalizer;
 
-            result = result * normalizer;
+        for i in 0..config.num_hidden_layers {
+            result = Model::layer(builder, config, i, &format!("model.layers.{i}"), result);
+        }
 
-            for i in 0..config.num_hidden_layers {
-                result = Model::layer(builder, config, i, &format!("model.layers.{i}"), result);
-            }
+        result = Model::rmsnorm(builder, config.rms_norm_eps, "model.norm", result);
 
-            result = Model::rmsnorm(builder, config.rms_norm_eps, "model.norm", result);
+        // Get the logits for the last token only
+        if tokens > 1 {
+            result = narrow(builder, 1, tokens - 1, 1, result);
+        }
 
-            // Get the logits for the last token only
-            if tokens > 1 {
-                result = narrow(builder, 1, tokens - 1, 1, result);
-            }
-
-            // Gemma uses weight tying so lm_head is the same as embed_tokens
-            let result = linear_no_bias(
-                builder,
-                config.hidden_size,
-                config.vocab_size,
-                "model.embed_tokens",
-                result,
-            );
-
-            (vec![x], vec![result])
-        });
-        state
+        // Gemma uses weight tying so lm_head is the same as embed_tokens
+        linear_no_bias(
+            builder,
+            config.hidden_size,
+            config.vocab_size,
+            "model.embed_tokens",
+            result,
+        )
     }
 }
 

--- a/examples/llm/llama.rs
+++ b/examples/llm/llama.rs
@@ -1,7 +1,7 @@
 // Llama-3 model description
 
 use super::{Config, ModelBuilder};
-use catgrad::backend::cpu::eval::{Builder, EvalState};
+use catgrad::backend::cpu::eval::Builder;
 use catgrad::core::nn::layers::*;
 use catgrad::core::{Dtype, NdArrayType, Shape, Var};
 
@@ -116,39 +116,33 @@ impl Model {
 }
 
 impl ModelBuilder for Model {
-    fn build(&mut self, batches: usize, tokens: usize, config: &Config) -> EvalState {
-        let in_type = NdArrayType::new(Shape(vec![batches, tokens]), Dtype::I32);
+    fn build(&self, builder: &Builder, config: &Config, x: Var) -> Var {
+        let tokens = x.label.shape.0[1];
+        let emb = Model::embeddings(builder, config, x.clone());
 
-        let state = EvalState::build(|builder| {
-            let x = Var::new(builder.clone(), in_type.clone());
-            let emb = Model::embeddings(builder, config, x.clone());
+        let mut result = emb;
 
-            let mut result = emb;
+        for i in 0..config.num_hidden_layers {
+            result = Model::layer(builder, config, &format!("model.layers.{i}"), result);
+        }
 
-            for i in 0..config.num_hidden_layers {
-                result = Model::layer(builder, config, &format!("model.layers.{i}"), result);
-            }
+        result = rmsnorm(builder, config.rms_norm_eps, "model.norm", result);
 
-            result = rmsnorm(builder, config.rms_norm_eps, "model.norm", result);
+        // Get the logits for the last token only
+        if tokens > 1 {
+            result = narrow(builder, 1, tokens - 1, 1, result);
+        }
 
-            // Get the logits for the last token only
-            if tokens > 1 {
-                result = narrow(builder, 1, tokens - 1, 1, result);
-            }
-
-            // Add lm_head if weight tying is used
-            if config.tie_word_embeddings {
-                result = linear_no_bias(
-                    builder,
-                    config.hidden_size,
-                    config.vocab_size,
-                    "model.embed_tokens",
-                    result,
-                );
-            }
-            (vec![x], vec![result])
-        });
-
-        state
+        // Add lm_head if weight tying is used
+        if config.tie_word_embeddings {
+            result = linear_no_bias(
+                builder,
+                config.hidden_size,
+                config.vocab_size,
+                "model.embed_tokens",
+                result,
+            );
+        }
+        result
     }
 }

--- a/examples/llm/olmo.rs
+++ b/examples/llm/olmo.rs
@@ -1,43 +1,36 @@
 // OLMo-2 model description
 
 use super::{Config, ModelBuilder};
-use catgrad::backend::cpu::eval::{Builder, EvalState};
+use catgrad::backend::cpu::eval::Builder;
 use catgrad::core::nn::layers::*;
 use catgrad::core::{Dtype, NdArrayType, Shape, Var};
 
 pub struct Model;
 
 impl ModelBuilder for Model {
-    fn build(&mut self, batches: usize, tokens: usize, config: &Config) -> EvalState {
-        let in_type = NdArrayType::new(Shape(vec![batches, tokens]), Dtype::I32);
+    fn build(&self, builder: &Builder, config: &Config, x: Var) -> Var {
+        let tokens = x.label.shape.0[1];
+        let emb = Model::embeddings(builder, config, x.clone());
+        let mut result = emb;
 
-        let state = EvalState::build(|builder| {
-            let x = Var::new(builder.clone(), in_type.clone());
-            let emb = Model::embeddings(builder, config, x.clone());
-            let mut result = emb;
+        for i in 0..config.num_hidden_layers {
+            result = Model::layer(builder, config, &format!("model.layers.{i}"), result);
+        }
 
-            for i in 0..config.num_hidden_layers {
-                result = Model::layer(builder, config, &format!("model.layers.{i}"), result);
-            }
+        result = rmsnorm(builder, config.rms_norm_eps, "model.norm", result);
 
-            result = rmsnorm(builder, config.rms_norm_eps, "model.norm", result);
+        // Get the logits for the last token only
+        if tokens > 1 {
+            result = narrow(builder, 1, tokens - 1, 1, result);
+        }
 
-            // Get the logits for the last token only
-            if tokens > 1 {
-                result = narrow(builder, 1, tokens - 1, 1, result);
-            }
-
-            let lm_head = linear_no_bias(
-                builder,
-                config.hidden_size,
-                config.vocab_size,
-                "lm_head",
-                result,
-            );
-
-            (vec![x], vec![lm_head])
-        });
-        state
+        linear_no_bias(
+            builder,
+            config.hidden_size,
+            config.vocab_size,
+            "lm_head",
+            result,
+        )
     }
 }
 

--- a/examples/llm/qwen.rs
+++ b/examples/llm/qwen.rs
@@ -1,44 +1,37 @@
 // Qwen-3 model description
 
 use super::{Config, ModelBuilder};
-use catgrad::backend::cpu::eval::{Builder, EvalState};
+use catgrad::backend::cpu::eval::Builder;
 use catgrad::core::nn::layers::*;
 use catgrad::core::{Dtype, NdArrayType, Shape, Var};
 
 pub struct Model;
 
 impl ModelBuilder for Model {
-    fn build(&mut self, batches: usize, tokens: usize, config: &Config) -> EvalState {
-        let in_type = NdArrayType::new(Shape(vec![batches, tokens]), Dtype::I32);
+    fn build(&self, builder: &Builder, config: &Config, x: Var) -> Var {
+        let tokens = x.label.shape.0[1];
+        let emb = Model::embeddings(builder, config, x.clone());
 
-        let state = EvalState::build(|builder| {
-            let x = Var::new(builder.clone(), in_type.clone());
-            let emb = Model::embeddings(builder, config, x.clone());
+        let mut result = emb;
 
-            let mut result = emb;
+        for i in 0..config.num_hidden_layers {
+            result = Model::layer(builder, config, &format!("model.layers.{i}"), result);
+        }
 
-            for i in 0..config.num_hidden_layers {
-                result = Model::layer(builder, config, &format!("model.layers.{i}"), result);
-            }
+        result = rmsnorm(builder, config.rms_norm_eps, "model.norm", result);
 
-            result = rmsnorm(builder, config.rms_norm_eps, "model.norm", result);
+        // Get the logits for the last token only
+        if tokens > 1 {
+            result = narrow(builder, 1, tokens - 1, 1, result);
+        }
 
-            // Get the logits for the last token only
-            if tokens > 1 {
-                result = narrow(builder, 1, tokens - 1, 1, result);
-            }
-
-            let result = linear_no_bias(
-                builder,
-                config.hidden_size,
-                config.vocab_size,
-                "lm_head",
-                result,
-            );
-
-            (vec![x], vec![result])
-        });
-        state
+        linear_no_bias(
+            builder,
+            config.hidden_size,
+            config.vocab_size,
+            "lm_head",
+            result,
+        )
     }
 }
 


### PR DESCRIPTION
Take out EvalState creation from model files, it's common code that belongs in main.
