### PR TITLE
WIP: --save-dot flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ half = "2.5.0"
 log = "0.4.27"
 test-log = "0.2.17"
 memmap2 = "0.9.5"
+open-hypergraphs-dot = "0.2.1"
+graphviz-rust = "0.9.5"
 
 [dev-dependencies]
 clap = { version = "4.5.37", features = ["derive"] }

--- a/src/backend/cpu/eval.rs
+++ b/src/backend/cpu/eval.rs
@@ -55,7 +55,7 @@ pub type Builder = Rc<RefCell<Term>>;
 /// Evaluator state for a single term.
 #[derive(Debug, Clone)]
 pub struct EvalState {
-    term: StrictTerm,
+    pub term: StrictTerm,
     data: Vec<TaggedNdArray>,
     parameters: Option<Rc<HashMap<String, TaggedNdArray>>>,
 }


### PR DESCRIPTION
WIP because the current structure of ModelRunner means --save-dot isn't actually run until after the model weights are loaded & starts to generate tokens