### PR TITLE
Add cache parameter, use precomputed Rope

### DIFF
--- a/examples/llm/gemma.rs
+++ b/examples/llm/gemma.rs
@@ -1,6 +1,6 @@
 // Gemma-3 model description
 
-use super::{Config, ModelBuilder};
+use super::{Cache, Config, ModelBuilder};
 use catgrad::backend::cpu::eval::Builder;
 use catgrad::core::nn::layers::*;
 use catgrad::core::{Dtype, NdArrayType, Shape, Var};
@@ -8,7 +8,7 @@ use catgrad::core::{Dtype, NdArrayType, Shape, Var};
 pub struct Model;
 
 impl ModelBuilder for Model {
-    fn build(&self, builder: &Builder, config: &Config, x: Var) -> Var {
+    fn build(&self, builder: &Builder, config: &Config, _cache: &mut Cache, x: Var) -> Var {
         let tokens = x.label.shape.0[1];
         let emb = Model::embeddings(builder, config, x);
 
@@ -131,7 +131,7 @@ impl Model {
         let attn = attn / denom;
 
         let mask = causal_mask(builder, s);
-        let mask = expand(builder, Shape(vec![b, num_heads, s, s]), mask);
+        let mask = expand(builder, attn.label.shape.clone(), mask);
         let attn = attn + mask;
 
         let attn = softmax(builder, attn);

--- a/examples/llm/gpt2.rs
+++ b/examples/llm/gpt2.rs
@@ -1,6 +1,6 @@
 // GPT-2 model description
 
-use super::{Config, ModelBuilder};
+use super::{Cache, Config, ModelBuilder};
 use catgrad::backend::cpu::eval::Builder;
 use catgrad::core::nn::layers::*;
 use catgrad::core::{Dtype, NdArrayType, Shape, Var};
@@ -79,7 +79,7 @@ impl Model {
         let attn = attn / denom;
 
         let mask = causal_mask(builder, s);
-        let mask = expand(builder, Shape(vec![b, num_heads, s, s]), mask);
+        let mask = expand(builder, attn.label.shape.clone(), mask);
         let attn = attn + mask;
 
         let attn = softmax(builder, attn);
@@ -122,7 +122,7 @@ impl Model {
 }
 
 impl ModelBuilder for Model {
-    fn build(&self, builder: &Builder, config: &Config, x: Var) -> Var {
+    fn build(&self, builder: &Builder, config: &Config, _cache: &mut Cache, x: Var) -> Var {
         let tokens = x.label.shape.0[1];
 
         let emb = Model::embeddings(builder, config, x);

--- a/examples/llm/phi.rs
+++ b/examples/llm/phi.rs
@@ -1,6 +1,6 @@
 // Phi-3 model description
 
-use super::{Config, ModelBuilder};
+use super::{Cache, Config, ModelBuilder};
 use catgrad::backend::cpu::eval::Builder;
 use catgrad::core::nn::layers::*;
 use catgrad::core::{Dtype, NdArrayType, Shape, Var};
@@ -17,7 +17,13 @@ impl Model {
         embedding(builder, x, weights)
     }
 
-    pub fn attention(builder: &Builder, config: &Config, name: &str, x: Var) -> Var {
+    pub fn attention(
+        builder: &Builder,
+        config: &Config,
+        cache: &mut Cache,
+        name: &str,
+        x: Var,
+    ) -> Var {
         let dim = config.hidden_size;
         let num_heads = config.num_attention_heads;
         let num_kv_heads = config.num_key_value_heads;
@@ -52,8 +58,8 @@ impl Model {
         let k = transpose(builder, 1, 2, k);
         let v = transpose(builder, 1, 2, v);
 
-        let q = rope(builder, config.rope_theta, s, q);
-        let k = rope(builder, config.rope_theta, s, k);
+        let q = apply_rope_embedding(builder, cache.cos.clone(), cache.sin.clone(), q);
+        let k = apply_rope_embedding(builder, cache.cos.clone(), cache.sin.clone(), k);
 
         let k = repeat_kv(builder, rep, k);
         let v = repeat_kv(builder, rep, v);
@@ -64,7 +70,7 @@ impl Model {
         let attn = attn / denom;
 
         let mask = causal_mask(builder, s);
-        let mask = expand(builder, Shape(vec![b, num_heads, s, s]), mask);
+        let mask = expand(builder, attn.label.shape.clone(), mask);
         let attn = attn + mask;
 
         let attn = softmax(builder, attn);
@@ -100,7 +106,7 @@ impl Model {
         x
     }
 
-    pub fn layer(builder: &Builder, config: &Config, name: &str, x: Var) -> Var {
+    pub fn layer(builder: &Builder, config: &Config, cache: &mut Cache, name: &str, x: Var) -> Var {
         let res = x.clone();
         let x = rmsnorm(
             builder,
@@ -108,7 +114,7 @@ impl Model {
             &format!("{name}.input_layernorm"),
             x,
         );
-        let x = Model::attention(builder, config, &format!("{name}.self_attn"), x);
+        let x = Model::attention(builder, config, cache, &format!("{name}.self_attn"), x);
         let x = res + x;
         let res = x.clone();
         let x = rmsnorm(
@@ -123,7 +129,7 @@ impl Model {
 }
 
 impl ModelBuilder for Model {
-    fn build(&self, builder: &Builder, config: &Config, x: Var) -> Var {
+    fn build(&self, builder: &Builder, config: &Config, cache: &mut Cache, x: Var) -> Var {
         let tokens = x.label.shape.0[1];
 
         let emb = Model::embeddings(builder, config, x);
@@ -131,7 +137,7 @@ impl ModelBuilder for Model {
         let mut result = emb;
 
         for i in 0..config.num_hidden_layers {
-            result = Model::layer(builder, config, &format!("model.layers.{i}"), result);
+            result = Model::layer(builder, config, cache, &format!("model.layers.{i}"), result);
         }
 
         // Get the logits for the last token only


### PR DESCRIPTION
Use precomputed Rope tables in all models except Gemma (two different tables needed depending on layer) and GPT-2 (it does not use Rope).
Add kv_cache field, not used yet.
Make the mask expand in attention use the shape of attention instead of using explicitly specified dims.