### PR TITLE
SmolLM3 fixed

### DIFF
--- a/catgrad-llm/Cargo.toml
+++ b/catgrad-llm/Cargo.toml
@@ -26,6 +26,7 @@ thiserror = "2.0"
 
 
 [dev-dependencies]
+chrono = "0.4.41"
 clap = { version = "4.5.37", features = ["derive"] }
 graphviz-rust = "0.9.5"
 open-hypergraphs-dot = "0.2.1"

--- a/catgrad-llm/examples/README.md
+++ b/catgrad-llm/examples/README.md
@@ -35,6 +35,8 @@ Here are links to some supported models to test the `llm` example with. All are 
 
 <https://huggingface.co/HuggingFaceTB/SmolLM2-135M-Instruct>
 
+<https://huggingface.co/HuggingFaceTB/SmolLM3-3B>
+
 <https://huggingface.co/Qwen/Qwen3-0.6B>
 
 <https://huggingface.co/google/gemma-3-1b-it>

--- a/catgrad-llm/examples/llm/llm.py
+++ b/catgrad-llm/examples/llm/llm.py
@@ -11,17 +11,31 @@ if __name__ == "__main__":
     )
     parser.add_argument("-p", "--prompt", type=str, default="Hello world")
     parser.add_argument("-s", "--seq-len", type=int, default=10)
+    parser.add_argument("-t", "--thinking", action="store_true")
     args = parser.parse_args()
 
     tokenizer = AutoTokenizer.from_pretrained(args.model)
     model = AutoModelForCausalLM.from_pretrained(args.model)
+
+    prompt = args.prompt
+
+    if tokenizer.chat_template is not None:
+        chat = [
+            {"role": "user", "content": prompt},
+        ]
+        prompt = tokenizer.apply_chat_template(
+            chat,
+            tokenize=False,
+            add_generation_prompt=True,
+            enable_thinking=args.thinking,
+        )
 
     # Remove model settings so generate does not warn about sampling parameters
     model.generation_config.temperature = None
     model.generation_config.top_p = None
     model.generation_config.top_k = None
 
-    inputs = tokenizer(args.prompt, return_tensors="pt")
+    inputs = tokenizer(prompt, return_tensors="pt")
     logits = model.generate(**inputs, max_new_tokens=args.seq_len, do_sample=False)
     output = tokenizer.decode(logits[0])
 

--- a/catgrad-llm/src/models/smollm3.rs
+++ b/catgrad-llm/src/models/smollm3.rs
@@ -40,17 +40,14 @@ impl ModelBuilder for Model {
             result = narrow(builder, 1, tokens - 1, 1, result);
         }
 
-        // Add lm_head if weight tying is used
-        if config.tie_word_embeddings {
-            result = linear_no_bias(
-                builder,
-                config.hidden_size,
-                config.vocab_size,
-                "model.embed_tokens",
-                result,
-            );
-        }
-        result
+        // Weight tying is used
+        linear_no_bias(
+            builder,
+            config.hidden_size,
+            config.vocab_size,
+            "model.embed_tokens",
+            result,
+        )
     }
 }
 

--- a/catgrad/src/backend/cpu/eval.rs
+++ b/catgrad/src/backend/cpu/eval.rs
@@ -324,7 +324,7 @@ impl EvalState {
                         // For each index, look up the corresponding embedding vector
                         for &idx in &flat_indices {
                             if idx < 0 || idx as usize >= weights.shape.0[0] {
-                                panic!("Embedding index out of bounds");
+                                panic!("Embedding index {idx} out of bounds");
                             }
 
                             let mut data = output.data.borrow_mut();


### PR DESCRIPTION
SmolLM3 needs to use weight tying even if not explicitly set in config.json.
Workaround for minijinja not parsing the SmolLM3 chat template fully.
These will need to be moved in the lib in a cleaner form.
Update the Python script.