### PR TITLE
Use rayon for parallel loading of weights

### DIFF
--- a/catgrad-llm/Cargo.toml
+++ b/catgrad-llm/Cargo.toml
@@ -22,6 +22,7 @@ safetensors = "0.6.0"
 log = "0.4.27"
 half = "2.6.0"
 thiserror = "2.0"
+rayon = "1.11.0"
 
 
 [dev-dependencies]

--- a/catgrad/Cargo.toml
+++ b/catgrad/Cargo.toml
@@ -16,7 +16,7 @@ half = "2.5.0"
 log = "0.4.27"
 test-log = "0.2.17"
 memmap2 = "0.9.5"
-rayon = "1.10.0"
+rayon = "1.11.0"
 num_cpus = "1.17.0"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"


### PR DESCRIPTION
Use multiple threads to make the loading of larger models noticeably faster.