### PR TITLE
Chunk

### DIFF
--- a/catgrad-llm/examples/siglip/main.rs
+++ b/catgrad-llm/examples/siglip/main.rs
@@ -248,8 +248,8 @@ fn vision_head_attention(
     let b_type = NdArrayType::new(Shape(vec![3 * dim]), x.label.dtype);
     let bias = parameter(builder, b_type, format!("{name}.in_proj_bias"));
 
-    let ws = split(builder, 0, 3, weight);
-    let bs = split(builder, 0, 3, bias);
+    let ws = chunk(builder, 0, 3, weight);
+    let bs = chunk(builder, 0, 3, bias);
 
     let q = linear_wb(builder, dim, dim, ws[0].clone(), bs[0].clone(), probe);
     let k = linear_wb(builder, dim, dim, ws[1].clone(), bs[1].clone(), x.clone());

--- a/catgrad-llm/src/models/gpt2.rs
+++ b/catgrad-llm/src/models/gpt2.rs
@@ -109,7 +109,7 @@ impl Model {
 
         let c_attn = Model::gpt_linear(builder, dim, 3 * dim, &format!("{name}.c_attn"), x);
 
-        let a = split(builder, 2, 3, c_attn);
+        let a = chunk(builder, 2, 3, c_attn);
         let q = a[0].clone();
         let k = a[1].clone();
         let v = a[2].clone();

--- a/catgrad-llm/src/models/granite.rs
+++ b/catgrad-llm/src/models/granite.rs
@@ -252,7 +252,7 @@ impl Model {
             for i in 0..config.num_experts_per_tok {
                 let gate_up = narrow(builder, 0, i, 1, moe_in.clone());
                 let out = narrow(builder, 0, i, 1, moe_out.clone());
-                let gate_up = split(builder, 1, 2, gate_up);
+                let gate_up = chunk(builder, 1, 2, gate_up);
                 let gate = gate_up[0].clone();
                 let up = gate_up[1].clone();
 

--- a/catgrad-llm/src/models/modernbert.rs
+++ b/catgrad-llm/src/models/modernbert.rs
@@ -161,7 +161,7 @@ impl Model {
             x,
         );
 
-        let input_gate = split(builder, 2, 2, x);
+        let input_gate = chunk(builder, 2, 2, x);
         let input = input_gate[0].clone();
         let gate = input_gate[1].clone();
         let x = gelu(builder, input) * gate;

--- a/catgrad-llm/src/models/phi.rs
+++ b/catgrad-llm/src/models/phi.rs
@@ -141,7 +141,7 @@ impl Model {
             x,
         );
 
-        let gate_up = split(builder, 2, 2, gate_up);
+        let gate_up = chunk(builder, 2, 2, gate_up);
 
         let gate = gate_up[0].clone();
         let up = gate_up[1].clone();

--- a/catgrad/src/backend/cpu/eval.rs
+++ b/catgrad/src/backend/cpu/eval.rs
@@ -351,6 +351,7 @@ impl EvalState {
                         Some(F32(a)) => {
                             let p = parameters.get(name);
                             if let Some(TaggedNdArray::F32(x)) = p {
+                                assert_eq!(x.shape, a.shape);
                                 a.data = Rc::clone(&x.data);
                             } else {
                                 panic!("Parameters loaded, parameter '{name}'::F32 not found.")
@@ -359,6 +360,7 @@ impl EvalState {
                         Some(F16(a)) => {
                             let p = parameters.get(name);
                             if let Some(TaggedNdArray::F16(x)) = p {
+                                assert_eq!(x.shape, a.shape);
                                 a.data = Rc::clone(&x.data);
                             } else {
                                 panic!("Parameters loaded, parameter '{name}'::F16 not found.")

--- a/catgrad/src/backend/cpu/kernel.rs
+++ b/catgrad/src/backend/cpu/kernel.rs
@@ -514,6 +514,7 @@ impl<T: Numeric> UnaryOp<T> for TransposeOp {
         b.strides = new_strides;
         b.offset = a.offset;
 
+        log::debug!("Transpose shapes from {:?} to {:?}", a.shape, b.shape);
         log::debug!("Transpose strides from {:?} to {:?}", a.strides, b.strides);
         b.data = Rc::clone(&a.data);
     }

--- a/catgrad/src/core/nn/layers.rs
+++ b/catgrad/src/core/nn/layers.rs
@@ -173,16 +173,7 @@ pub fn select(builder: &Builder, dim: usize, index: usize, x: Var) -> Var {
 }
 
 pub fn narrow(builder: &Builder, dim: usize, start: usize, length: usize, x: Var) -> Var {
-    assert!(
-        x.label.shape.0[dim] >= start + length,
-        "dim: {dim} {:?} >= {:?} + {:?}",
-        x.label.shape.0[dim],
-        start,
-        length
-    );
-
-    let indices = range_indices(builder, start, start + length);
-    index(builder, dim, x, indices)
+    slice(builder, dim, start, length, x)
 }
 
 pub fn concat(builder: &Builder, dim: usize, a: Var, b: Var) -> Var {

--- a/catgrad/src/core/nn/layers.rs
+++ b/catgrad/src/core/nn/layers.rs
@@ -123,21 +123,6 @@ pub fn chunk(builder: &Builder, dim: usize, chunks: usize, x: Var) -> Vec<Var> {
     outputs
 }
 
-pub fn split(builder: &Builder, dim: usize, splits: usize, x: Var) -> Vec<Var> {
-    assert!(x.label.shape.0[dim] % splits == 0);
-
-    let d = x.label.shape.0[dim] / splits;
-
-    let mut outputs = vec![];
-    for i in 0..splits {
-        let indices = range_indices(builder, i * d, (i + 1) * d);
-        let s = index(builder, dim, x.clone(), indices);
-        outputs.push(s);
-    }
-
-    outputs
-}
-
 pub fn squeeze(builder: &Builder, dim: usize, x: Var) -> Var {
     let mut output_shape = x.label.shape.0.clone();
     assert!(output_shape[dim] == 1);

--- a/catgrad/src/core/nn/layers.rs
+++ b/catgrad/src/core/nn/layers.rs
@@ -559,7 +559,7 @@ pub fn rope_tables(builder: &Builder, theta: f32, seq_len: usize, head_dim: usiz
 }
 
 fn rotate_half(builder: &Builder, x: Var) -> Var {
-    let v = split(builder, 3, 2, x);
+    let v = chunk(builder, 3, 2, x);
 
     concat(builder, 3, -v[1].clone(), v[0].clone())
 }
@@ -1217,14 +1217,14 @@ mod tests {
     }
 
     #[test]
-    fn test_split() {
+    fn test_chunk() {
         let mut state = EvalState::build(|builder| {
             let x = arange(builder, 6, Dtype::F32);
             let x = expand(builder, Shape(vec![4, 6]), x);
-            let v = split(builder, 1, 3, x);
+            let v = chunk(builder, 1, 3, x);
             let [y0, y1, y2]: [Var; 3] = v.try_into().unwrap();
 
-            let v = split(builder, 0, 2, y1);
+            let v = chunk(builder, 0, 2, y1);
             let y1 = v[0].clone();
 
             (vec![], vec![y0, y1, y2])


### PR DESCRIPTION
* Use the newly introduced Slice op to implement `narrow` and `chunk`
* Replace current uses of `split` with `chunk` to match Pytorch API naming. These are very similar functions, `chunk` takes the _number_ of equal-sized sections to divide the tensor in, while `split` takes the _size_ of each section.
* The only heavy user of split so far is GraniteMoE, this is where using slice instead of alloc+copying shows, so it gets about a 4x speedup (it is still very slow because it is the heaviest user of Index too)