### PR TITLE
A few small changes

### DIFF
--- a/catgrad-llm/examples/llm/llm.py
+++ b/catgrad-llm/examples/llm/llm.py
@@ -1,3 +1,4 @@
+import torch
 import argparse
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
@@ -14,11 +15,15 @@ if __name__ == "__main__":
     parser.add_argument("-s", "--seq-len", type=int, default=10)
     parser.add_argument("-r", "--raw-prompt", action="store_true")
     parser.add_argument("-t", "--thinking", action="store_true")
+    parser.add_argument("-d", "--dtype", type=str, default="float32")
     args = parser.parse_args()
 
     tokenizer = AutoTokenizer.from_pretrained(args.model, revision=args.revision)
-    model = AutoModelForCausalLM.from_pretrained(args.model, revision=args.revision)
+    model = AutoModelForCausalLM.from_pretrained(
+        args.model, revision=args.revision, dtype=args.dtype
+    )
 
+    print(f"Loaded model {args.model}, dtype:{model.dtype}")
     prompt = args.prompt
 
     if not args.raw_prompt and tokenizer.chat_template is not None:

--- a/catgrad-llm/src/nn/layers.rs
+++ b/catgrad-llm/src/nn/layers.rs
@@ -179,6 +179,11 @@ pub fn constant(builder: &Builder, param_type: NdArrayType, k: f32) -> Var {
     operation(builder, &[], param_type, op)
 }
 
+pub fn scalar(builder: &Builder, dtype: Dtype, k: f32) -> Var {
+    let scalar_type = NdArrayType::new(Shape(vec![1]), dtype);
+    constant(builder, scalar_type.clone(), k)
+}
+
 pub fn lt(builder: &Builder, a: Var, b: Var) -> Var {
     let op = Operation::LT;
     operation(builder, &[a.clone(), b], a.label, op)

--- a/catgrad/src/backend/cpu/eval.rs
+++ b/catgrad/src/backend/cpu/eval.rs
@@ -214,6 +214,11 @@ impl EvalState {
                         dim0: *dim0,
                         dim1: *dim1,
                     }),
+                    Slice { dim, start, length } => Box::new(kernel::SliceOp {
+                        dim: *dim,
+                        start: *start,
+                        length: *length,
+                    }),
                     Max => Box::new(kernel::MaxOp),
                     Sum => Box::new(kernel::SumOp),
                     _ => panic!("invalid operation"),


### PR DESCRIPTION
SliceOp for int, a scalar() helper, allow passing dtype to llm.py