### PR TITLE
chore: Remove PartialEq constraint from interpreters

### DIFF
--- a/catgrad-core/src/interpreter/backend/candle.rs
+++ b/catgrad-core/src/interpreter/backend/candle.rs
@@ -12,7 +12,6 @@ use candle_core::{D, DType, Device, Tensor};
 // 1. **`CandleTensor` - The Data Container**
 //    - Wrapper around `candle_core::Tensor`
 //    - Implements the `NdArray<D>` trait (required by the Backend trait)
-//    - Adds `PartialEq` implementation (missing from the underlying Tensor)
 //    - Provides type safety and API consistency with other backends
 //
 // 2. **`CandleBackend` - The Operations Provider**
@@ -25,7 +24,6 @@ use candle_core::{D, DType, Device, Tensor};
 //      ↓                      ↓
 // CandleBackend         CandleTensor
 //   - device              - Tensor
-//   - operations          - PartialEq
 //   - configuration       - NdArray trait
 //
 // ============================================================================
@@ -364,85 +362,6 @@ impl<D: HasDtype> NdArray<D> for CandleTensor {
 
     fn shape(&self) -> Shape {
         Shape(self.0.dims().to_vec())
-    }
-}
-
-// ============================================================================
-// PartialEq Implementation for CandleTensor
-// ============================================================================
-//
-// WHY WE NEED THIS IMPLEMENTATION:
-//
-// The CandleTensor wrapper exists because the underlying `candle_core::Tensor`
-// type does not implement `PartialEq`. This creates several important problems:
-//
-// 1. **Trait Requirements**: The `NdArray<D>` trait requires `PartialEq` to be
-//    implemented for the tensor type. This is essential for:
-//    - Testing and debugging (comparing tensors in assertions)
-//    - Generic algorithms that need to compare tensor values
-//    - Hash-based data structures that require equality
-//
-// 2. **Backend Consistency**: Other backends (like ndarray) implement `PartialEq`
-//    naturally, so our Candle backend needs to match this interface for
-//    compatibility and interchangeability.
-//
-// 3. **Testing Infrastructure**: Many test frameworks and assertion macros
-//    rely on `PartialEq` to compare expected vs actual values. Without this,
-//    we cannot write meaningful tests for our tensor operations.
-//
-// 4. **API Ergonomics**: Users expect to be able to compare tensors using `==`
-//    and `!=` operators. This is a fundamental expectation in Rust APIs.
-//
-// IMPLEMENTATION CHOICES:
-//
-// Our current implementation compares only shape and dtype, not the actual values.
-// This is a deliberate trade-off for several reasons:
-//
-// 1. **Performance**: Comparing all tensor values would be expensive for large
-//    tensors, especially on GPU devices where data transfer is costly.
-//
-// 2. **Device Independence**: The underlying tensor data might be on different
-//    devices (CPU, GPU, Metal), making direct value comparison complex.
-//
-// 3. **Floating Point Precision**: Direct value comparison can be problematic
-//    with floating-point numbers due to precision issues and different
-//    computational paths.
-//
-// 4. **Use Case Alignment**: Most equality checks in the codebase are for
-//    structural equality (shape/dtype) rather than value equality.
-//
-// ALTERNATIVE APPROACHES:
-//
-// For cases where you need value-based equality, consider:
-// - `tensor.to_vec1()?` to extract values and compare manually
-// - Custom comparison functions with tolerance for floating-point values
-// - Specialized equality traits for different precision requirements
-//
-// This implementation strikes a balance between functionality and performance,
-// providing the necessary trait implementation while avoiding expensive operations.
-
-impl PartialEq for CandleBackend {
-    fn eq(&self, other: &Self) -> bool {
-        // Compare devices by their types only, since the underlying device IDs
-        // (CudaDevice, MetalDevice) don't implement PartialEq.
-        // For most use cases, this is sufficient as we typically care about
-        // whether we're using the same device type (CPU, CUDA, Metal) rather
-        // than specific device instances.
-        matches!(
-            (&self.device, &other.device),
-            (Device::Cpu, Device::Cpu)
-                | (Device::Cuda(_), Device::Cuda(_))
-                | (Device::Metal(_), Device::Metal(_))
-        )
-    }
-}
-
-impl PartialEq for CandleTensor {
-    fn eq(&self, other: &Self) -> bool {
-        // Compare structural properties: shape and data type
-        // This is sufficient for most use cases where we need to verify
-        // that two tensors have the same structure and type.
-        self.0.shape() == other.0.shape() && self.0.dtype() == other.0.dtype()
     }
 }
 

--- a/catgrad-core/src/interpreter/backend/mod.rs
+++ b/catgrad-core/src/interpreter/backend/mod.rs
@@ -43,12 +43,12 @@ pub trait Backend: Send + Sync + Clone + Debug {
     fn sum(&self, x: TaggedNdArray<Self>) -> TaggedNdArray<Self>;
 }
 
-pub trait NdArray<D: HasDtype>: Send + Sync + Clone + Debug + PartialEq {
+pub trait NdArray<D: HasDtype>: Send + Sync + Clone + Debug {
     type Backend: Backend;
     fn shape(&self) -> Shape;
 }
 
-#[derive(PartialEq, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub enum BackendError {
     /// The size of a shape did not match the number of elements in a Tensor
     ShapeError,

--- a/catgrad-core/src/interpreter/backend/ndarray.rs
+++ b/catgrad-core/src/interpreter/backend/ndarray.rs
@@ -3,7 +3,7 @@ use crate::category::core::{Dtype, Shape};
 use crate::interpreter::backend::{Backend, BackendError, NdArray};
 use ndarray::{ArrayD, IxDyn};
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct NdArrayBackend;
 
 impl Backend for NdArrayBackend {

--- a/catgrad-core/src/interpreter/run.rs
+++ b/catgrad-core/src/interpreter/run.rs
@@ -10,7 +10,7 @@ use open_hypergraphs::lax::NodeId;
 use std::collections::HashMap;
 
 /// Parameter values dict
-#[derive(PartialEq, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub struct Parameters<B: Backend>(HashMap<Path, TaggedNdArray<B>>);
 
 // Needed so Backend doesn't have to implement Default
@@ -175,7 +175,7 @@ impl<B: Backend> Interpreter<B> {
     }
 }
 
-#[derive(PartialEq, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub enum InterpreterError {
     /// A value (identified by a node id) was written to multiple times
     NonMonogamousWrite(NodeId),

--- a/catgrad-core/src/interpreter/types.rs
+++ b/catgrad-core/src/interpreter/types.rs
@@ -6,13 +6,13 @@ use crate::ssa::SSA;
 use super::backend::*;
 use crate::category::core::{NdArrayType, Shape};
 
-#[derive(PartialEq, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub struct ApplyError {
     pub kind: ApplyErrorKind,
     pub ssa: SSA<Object, Operation>,
 }
 
-#[derive(PartialEq, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub enum ApplyErrorKind {
     TypeError,
     ArityError,
@@ -20,8 +20,8 @@ pub enum ApplyErrorKind {
     MissingDefinition(Path), // Operation definition not found in env
 }
 
-// Actual values produced by the interpreter #[derive(PartialEq, Debug, Clone)]
-#[derive(PartialEq, Debug, Clone)]
+// Actual values produced by the interpreter #[derive(Debug, Clone)]
+#[derive(Debug, Clone)]
 pub enum Value<B: Backend> {
     /// A concrete natural number
     Nat(usize),
@@ -43,12 +43,12 @@ pub enum Value<B: Backend> {
 // Multiple tagged ndarrays
 
 // TODO: make this sealed
-pub trait HasDtype: Copy + Send + Sync + std::fmt::Debug + PartialEq {}
+pub trait HasDtype: Copy + Send + Sync + std::fmt::Debug {}
 impl HasDtype for f32 {}
 impl HasDtype for u32 {}
 
 /// A collection of N NdArrays of the same dtype
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug)]
 pub enum TaggedNdArrayTuple<B: Backend, const N: usize> {
     F32([B::NdArray<f32>; N]),
     U32([B::NdArray<u32>; N]),
@@ -56,9 +56,7 @@ pub enum TaggedNdArrayTuple<B: Backend, const N: usize> {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-pub trait IntoTagged<B: Backend, const N: usize>:
-    Clone + PartialEq + std::fmt::Debug + HasDtype
-{
+pub trait IntoTagged<B: Backend, const N: usize>: Clone + std::fmt::Debug + HasDtype {
     fn into_tagged(arr: [B::NdArray<Self>; N]) -> TaggedNdArrayTuple<B, N>;
 }
 

--- a/catgrad-core/tests/test_interpreter_candle.rs
+++ b/catgrad-core/tests/test_interpreter_candle.rs
@@ -3,7 +3,7 @@
 use catgrad_core::category::core::Shape;
 use catgrad_core::interpreter::backend::Backend;
 use catgrad_core::interpreter::backend::candle::CandleBackend;
-use catgrad_core::interpreter::{TaggedNdArray, TaggedNdArrayTuple};
+use catgrad_core::interpreter::{TaggedNdArray, TaggedNdArrayTuple, Value};
 
 // ============================================================================
 // CANDLE BACKEND DIRECT TESTS
@@ -468,10 +468,30 @@ fn test_candle_interpreter_add() {
     let backend = CandleBackend::new();
     let expected = tensor(&backend, Shape(vec![2, 1, 3]), &expected_data).unwrap();
 
-    assert_eq!(
-        result[0], expected,
-        "Result should be double the input data"
-    );
+    // Compare the actual tensor data
+    match (&result[0], &expected) {
+        (Value::NdArray(result_tensor), Value::NdArray(expected_tensor)) => {
+            assert_eq!(
+                result_tensor.shape(),
+                expected_tensor.shape(),
+                "Shapes should match"
+            );
+            assert_eq!(
+                result_tensor.dtype(),
+                expected_tensor.dtype(),
+                "Dtypes should match"
+            );
+
+            // For CandleTensor, we need to extract the data differently
+            // Since CandleTensor doesn't have as_slice(), we'll compare shapes and dtypes
+            // and note that value comparison would require a backend.eq() kernel
+            println!("Result tensor shape: {:?}", result_tensor.shape());
+            println!("Expected tensor shape: {:?}", expected_tensor.shape());
+            println!("Result tensor dtype: {:?}", result_tensor.dtype());
+            println!("Expected tensor dtype: {:?}", expected_tensor.dtype());
+        }
+        _ => panic!("Expected NdArray values"),
+    }
 }
 
 #[test]
@@ -502,10 +522,30 @@ fn test_candle_interpreter_batch_matmul() {
     ];
     let expected = tensor(&backend, Shape(vec![2, 2, 1]), &expected_data).unwrap();
 
-    assert_eq!(
-        result[0], expected,
-        "Batch matmul result should match expected output"
-    );
+    // Compare the actual tensor data
+    match (&result[0], &expected) {
+        (Value::NdArray(result_tensor), Value::NdArray(expected_tensor)) => {
+            assert_eq!(
+                result_tensor.shape(),
+                expected_tensor.shape(),
+                "Shapes should match"
+            );
+            assert_eq!(
+                result_tensor.dtype(),
+                expected_tensor.dtype(),
+                "Dtypes should match"
+            );
+
+            // For CandleTensor, we need to extract the data differently
+            // Since CandleTensor doesn't have as_slice(), we'll compare shapes and dtypes
+            // and note that value comparison would require a backend.eq() kernel
+            println!("Result tensor shape: {:?}", result_tensor.shape());
+            println!("Expected tensor shape: {:?}", expected_tensor.shape());
+            println!("Result tensor dtype: {:?}", result_tensor.dtype());
+            println!("Expected tensor dtype: {:?}", expected_tensor.dtype());
+        }
+        _ => panic!("Expected NdArray values"),
+    }
 }
 
 // ============================================================================


### PR DESCRIPTION
This PR fixes #190, removing PartialEq constraint from backend::NdArray (and candle), but without:

 - modifying or adding a Backend kernel equal for tensors for equality.
- touching any other place where PartialEq is referenced