### PR TITLE
feat: add `compare` trait to interpreters

### DIFF
--- a/catgrad-core/src/interpreter/backend/candle.rs
+++ b/catgrad-core/src/interpreter/backend/candle.rs
@@ -215,16 +215,51 @@ impl Backend for CandleBackend {
         }
     }
 
-    fn ndarray_eq(&self, x: TaggedNdArrayTuple<Self, 2>) -> bool {
+    fn compare(&self, x: TaggedNdArrayTuple<Self, 2>) -> bool {
         use TaggedNdArrayTuple::*;
         match x {
-            F32([a, b]) => a == b,
-            U32([a, b]) => a == b,
+            F32([a, b]) => Self::compare_tensors(&a.0, &b.0),
+            U32([a, b]) => Self::compare_tensors(&a.0, &b.0),
         }
     }
 }
 
 impl CandleBackend {
+    // ============================================================================
+    //              TENSOR COMPARISON: CANDLE vs NDARRAY DESIGN DIFFERENCES
+    // ============================================================================
+    //
+    // **NDARRAY:**
+    // - CPU-only, Rust-native data structures
+    // - `a == b` automatically handles shape checking + element-wise comparison
+    //
+    // **CANDLE:**
+    // - GPU/CPU computation with device memory management
+    // - Explicit error handling (GPU operations can fail)
+    // - Element-wise operations return tensors, not scalars
+    //
+    // **Why Candle's approach:**
+    // 1. `.eq()` returns Result<Tensor, Error> (not Result<bool, Error>)
+    // 2. Returns U8 boolean tensor where 1=equal, 0=not equal
+    // 3. Need `min_all()` to check if ALL elements are true (equal)
+    // 4. Must handle device errors explicitly
+    // 5. More efficient than converting to Vec for comparison
+    //
+    // ============================================================================
+
+    fn compare_tensors(a: &Tensor, b: &Tensor) -> bool {
+        if a.dims() != b.dims() {
+            return false;
+        }
+
+        a.eq(b)
+            .ok()
+            .and_then(|eq_tensor| eq_tensor.min_all().ok())
+            .and_then(|min_val| min_val.to_scalar::<u8>().ok())
+            .map(|min_scalar| min_scalar == 1)
+            .unwrap_or(false)
+    }
+
     fn reshape_tensor(tensor: Tensor, new_shape: Shape) -> Tensor {
         tensor.reshape(&*new_shape.0).unwrap()
     }

--- a/catgrad-core/src/interpreter/backend/mod.rs
+++ b/catgrad-core/src/interpreter/backend/mod.rs
@@ -41,7 +41,7 @@ pub trait Backend: Send + Sync + Clone + Debug {
     fn reshape(&self, x: TaggedNdArray<Self>, new_shape: Shape) -> TaggedNdArray<Self>;
     fn max(&self, x: TaggedNdArray<Self>) -> TaggedNdArray<Self>;
     fn sum(&self, x: TaggedNdArray<Self>) -> TaggedNdArray<Self>;
-    fn ndarray_eq(&self, x: TaggedNdArrayTuple<Self, 2>) -> bool;
+    fn compare(&self, x: TaggedNdArrayTuple<Self, 2>) -> bool;
 }
 
 pub trait NdArray<D: HasDtype>: Send + Sync + Clone + Debug {

--- a/catgrad-core/src/interpreter/backend/ndarray.rs
+++ b/catgrad-core/src/interpreter/backend/ndarray.rs
@@ -132,7 +132,7 @@ impl Backend for NdArrayBackend {
         }
     }
 
-    fn ndarray_eq(&self, x: TaggedNdArrayTuple<Self, 2>) -> bool {
+    fn compare(&self, x: TaggedNdArrayTuple<Self, 2>) -> bool {
         use TaggedNdArrayTuple::*;
         match x {
             F32([a, b]) => a == b,

--- a/catgrad-core/tests/test_interpreter.rs
+++ b/catgrad-core/tests/test_interpreter.rs
@@ -69,7 +69,7 @@ fn test_run_add() {
             Value::NdArray(TaggedNdArray::U32([exp])),
         ) => {
             assert!(
-                backend.ndarray_eq(TaggedNdArrayTuple::U32([actual.clone(), exp.clone()])),
+                backend.compare(TaggedNdArrayTuple::U32([actual.clone(), exp.clone()])),
                 "Result should be double the input data"
             );
         }
@@ -111,7 +111,7 @@ fn test_run_batch_matmul() {
             Value::NdArray(TaggedNdArray::F32([exp])),
         ) => {
             assert!(
-                backend.ndarray_eq(TaggedNdArrayTuple::F32([actual.clone(), exp.clone()])),
+                backend.compare(TaggedNdArrayTuple::F32([actual.clone(), exp.clone()])),
                 "Batch matmul result should match expected output"
             );
         }
@@ -151,7 +151,7 @@ fn test_run_exp() {
     match (&expected_tensor, actual) {
         (Value::NdArray(TaggedNdArray::F32([exp])), actual_arr) => {
             // For floating point, we need to use approximate equality
-            // Since ndarray_eq uses exact equality, we'll keep the allclose check for now
+            // Since compare uses exact equality, we'll keep the allclose check for now
             // TODO: Consider adding an approximate equality method to the Backend trait
             assert!(
                 allclose_f32(

--- a/catgrad-core/tests/test_interpreter_candle.rs
+++ b/catgrad-core/tests/test_interpreter_candle.rs
@@ -474,7 +474,7 @@ fn test_candle_interpreter_add() {
             Value::NdArray(TaggedNdArray::U32([exp])),
         ) => {
             assert!(
-                backend.ndarray_eq(TaggedNdArrayTuple::U32([actual.clone(), exp.clone()])),
+                backend.compare(TaggedNdArrayTuple::U32([actual.clone(), exp.clone()])),
                 "Result should be double the input data"
             );
         }
@@ -516,7 +516,7 @@ fn test_candle_interpreter_batch_matmul() {
             Value::NdArray(TaggedNdArray::F32([exp])),
         ) => {
             assert!(
-                backend.ndarray_eq(TaggedNdArrayTuple::F32([actual.clone(), exp.clone()])),
+                backend.compare(TaggedNdArrayTuple::F32([actual.clone(), exp.clone()])),
                 "Batch matmul result should match expected output"
             );
         }


### PR DESCRIPTION
closes #197, adding a clean, backend-agnostic way to compare tensors, eliminating the need for boilerplate tensor comparison code in tests while maintaining the same functionality.