### PR TITLE
Bump open hypergraphs to 0.2.6, remove utils

### DIFF
--- a/catgrad-core/Cargo.toml
+++ b/catgrad-core/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-open-hypergraphs = "0.2.3"
+open-hypergraphs = "0.2.6"
 graphviz-rust = { version = "0.9.5", optional = true }
 open-hypergraphs-dot = { version = "0.2.1", optional = true }
 

--- a/catgrad-core/examples/hidden.rs
+++ b/catgrad-core/examples/hidden.rs
@@ -1,7 +1,5 @@
-use catgrad_core::prelude::*;
-use catgrad_core::util::replace_nodes_in_hypergraph;
-
 use catgrad_core::interpreter;
+use catgrad_core::prelude::*;
 
 use std::collections::HashMap;
 
@@ -26,8 +24,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         check::check(&env, &parameters, typed_term.clone()).expect("typecheck failed");
 
     // Diagram of term with shapes inferred
-    let labeled_term = replace_nodes_in_hypergraph(typed_term.term.clone(), check_result);
-    save_svg(&labeled_term, &format!("{}_typed.svg", model.path()))?;
+    let labeled_term = typed_term.term.clone().with_nodes(|_| check_result);
+    let filename = &format!("{}_typed.svg", model.path());
+    save_svg(&labeled_term.unwrap(), filename)?;
 
     // Choose a backend from available features
     let backend = select_backend()?;

--- a/catgrad-core/src/util.rs
+++ b/catgrad-core/src/util.rs
@@ -24,20 +24,3 @@ where
 pub(crate) fn iter_to_array<T, const N: usize>(iter: impl Iterator<Item = T>) -> Option<[T; N]> {
     iter.collect::<Vec<T>>().try_into().ok()
 }
-
-pub fn replace_nodes_in_hypergraph<T, U, V>(
-    term: OpenHypergraph<T, U>,
-    new_nodes: Vec<V>,
-) -> OpenHypergraph<V, U> {
-    use open_hypergraphs::lax::Hypergraph;
-    OpenHypergraph {
-        hypergraph: Hypergraph {
-            nodes: new_nodes,
-            edges: term.hypergraph.edges,
-            adjacency: term.hypergraph.adjacency,
-            quotient: term.hypergraph.quotient,
-        },
-        sources: term.sources,
-        targets: term.targets,
-    }
-}

--- a/catgrad-core/tests/test_lang.rs
+++ b/catgrad-core/tests/test_lang.rs
@@ -1,7 +1,6 @@
 use catgrad_core::category::lang::*;
 use catgrad_core::check::*;
 use catgrad_core::stdlib::*;
-use catgrad_core::util::replace_nodes_in_hypergraph;
 
 pub mod test_utils;
 use test_utils::{get_forget_core_declarations, save_diagram_if_enabled};
@@ -70,7 +69,7 @@ pub fn run_check_test(
     let result = check_with(&env, &Parameters::default(), term.clone(), source_type)?;
     println!("result: {result:?}");
 
-    let typed_term = replace_nodes_in_hypergraph(term, result);
+    let typed_term = term.with_nodes(|_| result).unwrap();
     save_diagram_if_enabled(svg_filename, &typed_term);
 
     Ok(())


### PR DESCRIPTION
util::replace_nodes_in_hypergraph is superseded by OpenHypergraph::with_nodes