### PR TITLE
Feature/explicit to core pass

### DIFF
--- a/catgrad-core/src/category/core.rs
+++ b/catgrad-core/src/category/core.rs
@@ -1,8 +1,15 @@
 //! Core operations on shapes, natural numbers, and tensors.
 //! A simple, portable IR.
 
+use crate::definition::Def;
+use crate::path::Path;
+use open_hypergraphs::lax::OpenHypergraph;
+
 ////////////////////////////////////////////////////////////////////////////////
 // Basic types.
+
+// a core::Term is an open hypergraph with adjoined definitions named by Paths
+pub type Term = OpenHypergraph<Object, Def<Path, Operation>>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NdArrayType {

--- a/catgrad-core/src/category/core.rs
+++ b/catgrad-core/src/category/core.rs
@@ -134,7 +134,7 @@ pub enum TypeOp {
 #[derive(Debug, Clone, PartialEq)]
 pub enum Constant {
     F32(f32),
-    U32(i32),
+    U32(u32),
 }
 
 /// Generating tensor operations

--- a/catgrad-core/src/definition/mod.rs
+++ b/catgrad-core/src/definition/mod.rs
@@ -1,0 +1,2 @@
+pub mod types;
+pub use types::*;

--- a/catgrad-core/src/definition/types.rs
+++ b/catgrad-core/src/definition/types.rs
@@ -1,0 +1,25 @@
+//! # Categories with *definitions*
+//!
+//! Allows extending a set of ops with some additional definitions.
+//! For example, extend the set of ops `{add, negate}` with `sub := x y ↦  add(x, negate(y))`.
+//!
+//! Formally, given an symmetric monoidal theory `T = (Σ₀, Σ₁, Σ₂)`.
+//! Def(T) is the theory presented by `(Σ₀, Σ₁ + K, Σ₂ + R)` where:
+//! - `K` is a set of adjoined operations - (e.g. `{sub}`)
+//! - `R` is a set of rewrites, one for each `k ∈ K`, expanding $k$ to its definition, e.g., `sub ⇝  x y ↦  add(x, negate(y))`.
+
+/// A set of operations Arr extended with some additional operations in the set K.
+/// `Def<K, Arr> ~= Σ₁ + K`
+#[derive(Clone, PartialEq, Debug)]
+pub enum Def<K, Arr> {
+    Def(K),
+    Arr(Arr),
+}
+
+use open_hypergraphs::lax::var::HasVar;
+
+impl<K, A: HasVar> HasVar for Def<K, A> {
+    fn var() -> Self {
+        Def::Arr(A::var())
+    }
+}

--- a/catgrad-core/src/lib.rs
+++ b/catgrad-core/src/lib.rs
@@ -10,6 +10,9 @@ pub mod check;
 pub mod interpreter;
 pub mod ssa;
 
+// general compiler tools
+pub mod definition;
+
 // Utilities
 #[cfg(feature = "svg")]
 pub mod svg;

--- a/catgrad-core/src/lib.rs
+++ b/catgrad-core/src/lib.rs
@@ -2,6 +2,9 @@
 pub mod category;
 pub mod stdlib;
 
+// Compiler passes
+pub mod pass;
+
 // path::Path is a type of dot-separated strings used to name definitions and lang ops.
 pub mod path;
 

--- a/catgrad-core/src/pass/mod.rs
+++ b/catgrad-core/src/pass/mod.rs
@@ -1,0 +1,1 @@
+pub mod to_core;

--- a/catgrad-core/src/pass/to_core.rs
+++ b/catgrad-core/src/pass/to_core.rs
@@ -1,0 +1,71 @@
+use std::collections::HashMap;
+
+use crate::category::{core, lang};
+use crate::definition::Def;
+
+/// Lower a `lang::Term` to a `core::Term`.
+/// If a Definition or Declaration was not a core operation, it is assumed to be a definition in
+/// [`core`].
+pub fn lang_to_core(term: lang::Term) -> core::Term {
+    let core_ops = core_declarations();
+
+    term.map_edges(|e| match e {
+        lang::Operation::Definition(path) => Def::Def(path),
+        lang::Operation::Declaration(path) => match core_ops.get(&path) {
+            Some(op) => Def::Arr(op.clone()),
+            None => Def::Def(path.clone()),
+        },
+        lang::Operation::Literal(lit) => Def::Arr(match lit {
+            lang::Literal::F32(x) => {
+                core::Operation::Tensor(core::TensorOp::Constant(core::Constant::F32(x)))
+            }
+            lang::Literal::U32(x) => {
+                core::Operation::Tensor(core::TensorOp::Constant(core::Constant::U32(x)))
+            }
+            lang::Literal::Nat(n) => core::Operation::Nat(core::NatOp::Constant(n as usize)),
+            lang::Literal::Dtype(d) => core::Operation::DtypeConstant(d),
+        }),
+    })
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// NOTE: below is duplicated from stdlib/ops.rs.
+// These should eventually replace that duplicate code!
+
+macro_rules! path{
+    [$($x:expr),* $(,)?] => {
+        vec![$($x),*].try_into().expect("invalid operation name")
+    };
+}
+
+/// Interpretations of declared operations
+fn core_declarations() -> HashMap<lang::Path, core::Operation> {
+    use crate::category::core::{NatOp, Operation, ScalarOp::*, TensorOp::*, TypeOp};
+    use std::collections::HashMap;
+    HashMap::from([
+        (path!["cartesian", "copy"], Operation::Copy),
+        // tensor ops (which actually affect tensor data)
+        (path!["tensor", "add"], Operation::Tensor(Map(Add))),
+        (path!["tensor", "neg"], Operation::Tensor(Map(Neg))),
+        (path!["tensor", "mul"], Operation::Tensor(Map(Mul))),
+        (path!["tensor", "div"], Operation::Tensor(Map(Div))),
+        (path!["tensor", "pow"], Operation::Tensor(Map(Pow))),
+        (path!["tensor", "matmul"], Operation::Tensor(MatMul)),
+        (path!["tensor", "reshape"], Operation::Tensor(Reshape)),
+        (path!["tensor", "broadcast"], Operation::Tensor(Broadcast)),
+        (path!["tensor", "cast"], Operation::Tensor(Cast)),
+        (path!["tensor", "index"], Operation::Tensor(Index)),
+        (path!["tensor", "sum"], Operation::Tensor(Sum)),
+        (path!["tensor", "max"], Operation::Tensor(Max)),
+        (path!["tensor", "arange"], Operation::Tensor(Arange)),
+        (path!["tensor", "concat"], Operation::Tensor(Concat)),
+        (path!["tensor", "scalar"], Operation::Tensor(Scalar)),
+        // Mixed Tensor/Type ops
+        (path!["tensor", "shape"], Operation::Type(TypeOp::Shape)),
+        (path!["tensor", "dtype"], Operation::Type(TypeOp::Dtype)),
+        // Shape ops
+        (path!["shape", "pack"], Operation::Type(TypeOp::Pack)),
+        (path!["shape", "unpack"], Operation::Type(TypeOp::Unpack)),
+        (path!["nat", "mul"], Operation::Nat(NatOp::Mul)),
+    ])
+}

--- a/catgrad-core/src/pass/to_core.rs
+++ b/catgrad-core/src/pass/to_core.rs
@@ -39,7 +39,7 @@ macro_rules! path{
 }
 
 /// Interpretations of declared operations
-fn core_declarations() -> HashMap<lang::Path, core::Operation> {
+pub(crate) fn core_declarations() -> HashMap<lang::Path, core::Operation> {
     use crate::category::core::{NatOp, Operation, ScalarOp::*, TensorOp::*, TypeOp};
     use std::collections::HashMap;
     HashMap::from([

--- a/catgrad-core/src/stdlib/ops.rs
+++ b/catgrad-core/src/stdlib/ops.rs
@@ -5,50 +5,12 @@ use super::def::*;
 
 use std::collections::HashMap;
 
-macro_rules! path{
-    [$($x:expr),* $(,)?] => {
-        vec![$($x),*].try_into().expect("invalid operation name")
-    };
-}
-
 /// Declared and defined operations.
 /// Currently, a declaration must map to a Core operation (subject to change!)
 #[derive(Debug, Clone)]
 pub struct Environment {
     pub definitions: HashMap<lang::Path, lang::TypedTerm>,
     pub declarations: HashMap<lang::Path, core::Operation>,
-}
-
-/// Interpretations of declared operations
-fn core_declarations() -> HashMap<lang::Path, core::Operation> {
-    use crate::category::core::{NatOp, Operation, ScalarOp::*, TensorOp::*, TypeOp};
-    use std::collections::HashMap;
-    HashMap::from([
-        (path!["cartesian", "copy"], Operation::Copy),
-        // tensor ops (which actually affect tensor data)
-        (path!["tensor", "add"], Operation::Tensor(Map(Add))),
-        (path!["tensor", "neg"], Operation::Tensor(Map(Neg))),
-        (path!["tensor", "mul"], Operation::Tensor(Map(Mul))),
-        (path!["tensor", "div"], Operation::Tensor(Map(Div))),
-        (path!["tensor", "pow"], Operation::Tensor(Map(Pow))),
-        (path!["tensor", "matmul"], Operation::Tensor(MatMul)),
-        (path!["tensor", "reshape"], Operation::Tensor(Reshape)),
-        (path!["tensor", "broadcast"], Operation::Tensor(Broadcast)),
-        (path!["tensor", "cast"], Operation::Tensor(Cast)),
-        (path!["tensor", "index"], Operation::Tensor(Index)),
-        (path!["tensor", "sum"], Operation::Tensor(Sum)),
-        (path!["tensor", "max"], Operation::Tensor(Max)),
-        (path!["tensor", "arange"], Operation::Tensor(Arange)),
-        (path!["tensor", "concat"], Operation::Tensor(Concat)),
-        (path!["tensor", "scalar"], Operation::Tensor(Scalar)),
-        // Mixed Tensor/Type ops
-        (path!["tensor", "shape"], Operation::Type(TypeOp::Shape)),
-        (path!["tensor", "dtype"], Operation::Type(TypeOp::Dtype)),
-        // Shape ops
-        (path!["shape", "pack"], Operation::Type(TypeOp::Pack)),
-        (path!["shape", "unpack"], Operation::Type(TypeOp::Unpack)),
-        (path!["nat", "mul"], Operation::Nat(NatOp::Mul)),
-    ])
 }
 
 // helper to simplify stdlib defs list
@@ -72,6 +34,8 @@ fn definitions() -> HashMap<lang::Path, lang::TypedTerm> {
 
 /// Standard library declarations and definitions
 pub fn stdlib() -> Environment {
+    use crate::pass::to_core::core_declarations;
+
     Environment {
         declarations: core_declarations(),
         definitions: definitions(),


### PR DESCRIPTION
Adds an explicit compiler pass from `lang::Term` to the (new) `core::Term`.
A `core::Term` is an OpenHypergraph with:

- Objects `core::Object` - same as `lang`
- Arrows: either a Path (definition name) or a `core::Operation`

The main point of this PR is the `lang_to_core` compiler pass function.
However, it also adds a new `Def` type (see docs) which will eventually replace the Operation enum in `lang`.