### PR TITLE
make interpreter run on `core` terms, not `lang`

### DIFF
--- a/catgrad-core/Cargo.toml
+++ b/catgrad-core/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-open-hypergraphs = "0.2.6"
+open-hypergraphs = "0.2.7"
 graphviz-rust = { version = "0.9.5", optional = true }
 open-hypergraphs-dot = { version = "0.2.1", optional = true }
 

--- a/catgrad-core/src/interpreter/run.rs
+++ b/catgrad-core/src/interpreter/run.rs
@@ -132,11 +132,12 @@ impl<B: Backend> Interpreter<B> {
     ) -> Result<Vec<Value<B>>, InterpreterError> {
         match &ssa.op {
             Def::Def(path) => self.apply_definition(ssa, args, path),
-            Def::Arr(op) => self.apply_declaration(ssa, args, op),
+            Def::Arr(op) => self.apply_op(ssa, args, op),
         }
     }
 
-    fn apply_declaration(
+    // Dispatch ops
+    fn apply_op(
         &self,
         ssa: &CoreSSA,
         args: Vec<Value<B>>,
@@ -156,6 +157,7 @@ impl<B: Backend> Interpreter<B> {
         })
     }
 
+    // Dispatch definitions by recursing
     fn apply_definition(
         &self,
         ssa: &CoreSSA,
@@ -168,6 +170,9 @@ impl<B: Backend> Interpreter<B> {
             ssa: ssa.clone(),
         })?;
 
+        // PERFORMANCE: we shouldn't really need to clone terms here;
+        // Interpreter only takes ownership because it has to call to_strict() to do the SSA
+        // decomposition. But this is not strictly necessary.
         self.run_core(definition.clone(), args)
     }
 

--- a/catgrad-core/src/interpreter/run.rs
+++ b/catgrad-core/src/interpreter/run.rs
@@ -2,9 +2,11 @@
 
 use super::backend::*;
 use super::types::*;
-use crate::category::{core, lang::*};
-use crate::ssa::{SSA, SSAError, parallel_ssa};
-use crate::stdlib::Environment;
+use crate::category::{core, core::*, lang};
+use crate::definition::Def;
+use crate::pass::to_core::{env_to_core, to_core};
+use crate::path::Path;
+use crate::ssa::{SSAError, parallel_ssa};
 
 use open_hypergraphs::lax::NodeId;
 use std::collections::HashMap;
@@ -12,6 +14,11 @@ use std::collections::HashMap;
 /// Parameter values dict
 #[derive(Clone, Debug)]
 pub struct Parameters<B: Backend>(HashMap<Path, TaggedNdArray<B>>);
+
+#[derive(Clone, Debug)]
+pub struct Environment {
+    pub definitions: HashMap<Path, core::Term>,
+}
 
 // Needed so Backend doesn't have to implement Default
 impl<B: Backend> Default for Parameters<B> {
@@ -43,7 +50,7 @@ pub struct Interpreter<B: Backend> {
 
 impl<B: Backend> Interpreter<B> {
     // specific to this interpreter (probably?)
-    pub fn new(backend: B, env: Environment, params: Parameters<B>) -> Self {
+    pub fn from_core(backend: B, env: Environment, params: Parameters<B>) -> Self {
         Self {
             backend,
             env,
@@ -51,10 +58,23 @@ impl<B: Backend> Interpreter<B> {
         }
     }
 
-    /// Run the interpreter with specified input values
+    pub fn new(backend: B, env: crate::stdlib::Environment, params: Parameters<B>) -> Self {
+        let env = env_to_core(env);
+        Self::from_core(backend, env, params)
+    }
+
     pub fn run(
         &self,
-        term: Term,
+        term: lang::Term,
+        values: Vec<Value<B>>,
+    ) -> Result<Vec<Value<B>>, InterpreterError> {
+        self.run_core(to_core(term), values)
+    }
+
+    /// Run the interpreter with specified input values
+    pub fn run_core(
+        &self,
+        term: core::Term,
         values: Vec<Value<B>>,
     ) -> Result<Vec<Value<B>>, InterpreterError> {
         assert_eq!(values.len(), term.sources.len());
@@ -105,39 +125,23 @@ impl<B: Backend> Interpreter<B> {
         Ok(target_values)
     }
 
-    fn get_op(
-        &self,
-        path: &Path,
-        ssa: &SSA<Object, Operation>,
-    ) -> Result<&core::Operation, InterpreterError> {
-        Ok(self.env.declarations.get(path).ok_or(ApplyError {
-            kind: ApplyErrorKind::MissingOperation(path.clone()),
-            ssa: ssa.clone(),
-        })?)
-    }
-
     pub fn apply(
         &self,
-        ssa: &SSA<Object, Operation>,
+        ssa: &CoreSSA,
         args: Vec<Value<B>>,
     ) -> Result<Vec<Value<B>>, InterpreterError> {
         match &ssa.op {
-            Operation::Literal(lit) => {
-                let v = lit_to_value(&self.backend, lit);
-                Ok(vec![v])
-            }
-            Operation::Declaration(path) => self.apply_declaration(ssa, args, path),
-            Operation::Definition(path) => self.apply_definition(ssa, args, path),
+            Def::Def(path) => self.apply_definition(ssa, args, path),
+            Def::Arr(op) => self.apply_declaration(ssa, args, op),
         }
     }
 
     fn apply_declaration(
         &self,
-        ssa: &SSA<Object, Operation>,
+        ssa: &CoreSSA,
         args: Vec<Value<B>>,
-        path: &Path,
+        op: &Operation,
     ) -> Result<Vec<Value<B>>, InterpreterError> {
-        let op = self.get_op(path, ssa)?;
         use super::shape_op::{apply_dtype_constant, apply_nat_op, apply_type_op};
         use super::tensor_op::apply_tensor_op;
         Ok(match op {
@@ -154,7 +158,7 @@ impl<B: Backend> Interpreter<B> {
 
     fn apply_definition(
         &self,
-        ssa: &SSA<Object, Operation>,
+        ssa: &CoreSSA,
         args: Vec<Value<B>>,
         def: &Path,
     ) -> Result<Vec<Value<B>>, InterpreterError> {
@@ -164,7 +168,7 @@ impl<B: Backend> Interpreter<B> {
             ssa: ssa.clone(),
         })?;
 
-        self.run(definition.term.clone(), args)
+        self.run_core(definition.clone(), args)
     }
 
     fn load(&self, path: &Path) -> Result<Vec<Value<B>>, InterpreterError> {
@@ -211,18 +215,9 @@ impl From<Box<ApplyError>> for InterpreterError {
     }
 }
 
-pub(crate) fn lit_to_value<B: Backend>(backend: &B, lit: &Literal) -> Value<B> {
-    match lit {
-        Literal::F32(x) => Value::NdArray(TaggedNdArray::F32([B::scalar(backend, *x)])),
-        Literal::U32(x) => Value::NdArray(TaggedNdArray::U32([B::scalar(backend, *x)])),
-        Literal::Dtype(d) => Value::Dtype(d.clone()),
-        Literal::Nat(x) => Value::Nat(*x as usize),
-    }
-}
-
 fn apply_copy<B: Backend>(
     mut args: Vec<Value<B>>,
-    ssa: &SSA<Object, Operation>,
+    ssa: &CoreSSA,
 ) -> Result<Vec<Value<B>>, Box<ApplyError>> {
     use super::shape_op::expect_arity;
     expect_arity(&args, 1, ssa)?;

--- a/catgrad-core/src/interpreter/shape_op.rs
+++ b/catgrad-core/src/interpreter/shape_op.rs
@@ -1,16 +1,15 @@
 //! Shape operation implementations for the interpreter
 
 use super::backend::Backend;
+use super::types::CoreSSA;
 use super::{ApplyError, ApplyErrorKind, Value};
-use crate::category::lang::{Object, Operation};
 use crate::category::{core, core::Shape};
-use crate::ssa::SSA;
 
 /// Apply a Type operation
 pub(crate) fn apply_type_op<B: Backend>(
     type_op: &core::TypeOp,
     args: Vec<Value<B>>,
-    ssa: &SSA<Object, Operation>,
+    ssa: &CoreSSA,
 ) -> Result<Vec<Value<B>>, Box<ApplyError>> {
     match type_op {
         core::TypeOp::Pack => apply_pack(args, ssa),
@@ -24,7 +23,7 @@ pub(crate) fn apply_type_op<B: Backend>(
 pub(crate) fn apply_nat_op<B: Backend>(
     nat_op: &core::NatOp,
     args: Vec<Value<B>>,
-    ssa: &SSA<Object, Operation>,
+    ssa: &CoreSSA,
 ) -> Result<Vec<Value<B>>, Box<ApplyError>> {
     match nat_op {
         core::NatOp::Constant(n) => apply_nat_constant(*n, args, ssa),
@@ -37,7 +36,7 @@ pub(crate) fn apply_nat_op<B: Backend>(
 pub(crate) fn apply_dtype_constant<B: Backend>(
     dtype: &core::Dtype,
     args: Vec<Value<B>>,
-    ssa: &SSA<Object, Operation>,
+    ssa: &CoreSSA,
 ) -> Result<Vec<Value<B>>, Box<ApplyError>> {
     expect_arity(&args, 0, ssa)?;
     Ok(vec![Value::Dtype(dtype.clone())])
@@ -46,7 +45,7 @@ pub(crate) fn apply_dtype_constant<B: Backend>(
 // Type operation implementations
 pub(crate) fn apply_pack<B: Backend>(
     args: Vec<Value<B>>,
-    ssa: &SSA<Object, Operation>,
+    ssa: &CoreSSA,
 ) -> Result<Vec<Value<B>>, Box<ApplyError>> {
     let mut shape = Vec::new();
     for arg in &args {
@@ -60,7 +59,7 @@ pub(crate) fn apply_pack<B: Backend>(
 
 pub(crate) fn apply_unpack<B: Backend>(
     args: Vec<Value<B>>,
-    ssa: &SSA<Object, Operation>,
+    ssa: &CoreSSA,
 ) -> Result<Vec<Value<B>>, Box<ApplyError>> {
     expect_arity(&args, 1, ssa)?;
     match &args[0] {
@@ -77,7 +76,7 @@ pub(crate) fn apply_unpack<B: Backend>(
 
 pub(crate) fn apply_shape<B: Backend>(
     args: Vec<Value<B>>,
-    ssa: &SSA<Object, Operation>,
+    ssa: &CoreSSA,
 ) -> Result<Vec<Value<B>>, Box<ApplyError>> {
     expect_arity(&args, 1, ssa)?;
     match &args[0] {
@@ -88,7 +87,7 @@ pub(crate) fn apply_shape<B: Backend>(
 
 pub(crate) fn apply_dtype<B: Backend>(
     args: Vec<Value<B>>,
-    ssa: &SSA<Object, Operation>,
+    ssa: &CoreSSA,
 ) -> Result<Vec<Value<B>>, Box<ApplyError>> {
     expect_arity(&args, 1, ssa)?;
     match &args[0] {
@@ -101,7 +100,7 @@ pub(crate) fn apply_dtype<B: Backend>(
 pub(crate) fn apply_nat_constant<B: Backend>(
     n: usize,
     args: Vec<Value<B>>,
-    ssa: &SSA<Object, Operation>,
+    ssa: &CoreSSA,
 ) -> Result<Vec<Value<B>>, Box<ApplyError>> {
     expect_arity(&args, 0, ssa)?;
     Ok(vec![Value::Nat(n)])
@@ -109,7 +108,7 @@ pub(crate) fn apply_nat_constant<B: Backend>(
 
 pub(crate) fn apply_nat_mul<B: Backend>(
     args: Vec<Value<B>>,
-    ssa: &SSA<Object, Operation>,
+    ssa: &CoreSSA,
 ) -> Result<Vec<Value<B>>, Box<ApplyError>> {
     if args.is_empty() {
         return Ok(vec![Value::Nat(1)]);
@@ -126,7 +125,7 @@ pub(crate) fn apply_nat_mul<B: Backend>(
 
 pub(crate) fn apply_nat_add<B: Backend>(
     args: Vec<Value<B>>,
-    ssa: &SSA<Object, Operation>,
+    ssa: &CoreSSA,
 ) -> Result<Vec<Value<B>>, Box<ApplyError>> {
     if args.is_empty() {
         return Ok(vec![Value::Nat(0)]);
@@ -144,9 +143,7 @@ pub(crate) fn apply_nat_add<B: Backend>(
 ////////////////////////////////////////////////////////////////////////////////
 // utilities
 
-pub fn type_error<B: Backend>(
-    ssa: &SSA<Object, Operation>,
-) -> Result<Vec<Value<B>>, Box<ApplyError>> {
+pub fn type_error<B: Backend>(ssa: &CoreSSA) -> Result<Vec<Value<B>>, Box<ApplyError>> {
     Err(Box::new(ApplyError {
         kind: ApplyErrorKind::TypeError,
         ssa: ssa.clone(),
@@ -156,7 +153,7 @@ pub fn type_error<B: Backend>(
 pub fn expect_arity<B: Backend>(
     args: &[Value<B>],
     expected: usize,
-    ssa: &SSA<Object, Operation>,
+    ssa: &CoreSSA,
 ) -> Result<(), Box<ApplyError>> {
     if args.len() != expected {
         type_error::<B>(ssa)?;

--- a/catgrad-core/src/interpreter/tensor_op.rs
+++ b/catgrad-core/src/interpreter/tensor_op.rs
@@ -50,7 +50,7 @@ pub(crate) fn tensor_constant<B: Backend>(
     ssa: &CoreSSA,
     c: &Constant,
 ) -> Result<Vec<Value<B>>, Box<ApplyError>> {
-    if args.len() != 0 {
+    if !args.is_empty() {
         return Err(err(ApplyErrorKind::ArityError, ssa));
     }
 

--- a/catgrad-core/src/interpreter/tensor_op.rs
+++ b/catgrad-core/src/interpreter/tensor_op.rs
@@ -1,21 +1,20 @@
 //! Tensor operation implementations for the interpreter
 
 use super::backend::*;
+use super::types::CoreSSA;
 use super::{ApplyError, ApplyErrorKind, TaggedNdArray, TaggedNdArrayTuple, Value};
-use crate::category::core::{Dtype, ScalarOp, TensorOp};
-use crate::category::lang::{Object, Operation};
-use crate::ssa::SSA;
+use crate::category::core::{Constant, Dtype, ScalarOp, TensorOp};
 
 /// Apply a Tensor operation
 pub(crate) fn apply_tensor_op<B: Backend>(
     backend: &B,
     tensor_op: &TensorOp,
     args: Vec<Value<B>>,
-    ssa: &SSA<Object, Operation>,
+    ssa: &CoreSSA,
 ) -> Result<Vec<Value<B>>, Box<ApplyError>> {
     match tensor_op {
         TensorOp::MatMul => binop(backend, args, ssa, B::matmul),
-        TensorOp::Constant(_constant) => todo!("constant"),
+        TensorOp::Constant(c) => tensor_constant(backend, args, ssa, c),
         TensorOp::Sum => tensor_sum(backend, args, ssa),
         TensorOp::Max => tensor_max(backend, args, ssa),
         TensorOp::Arange => tensor_arange(backend, args, ssa),
@@ -38,17 +37,36 @@ pub(crate) fn apply_tensor_op<B: Backend>(
     }
 }
 
-fn err<K: Into<ApplyErrorKind>>(kind: K, ssa: &SSA<Object, Operation>) -> Box<ApplyError> {
+fn err<K: Into<ApplyErrorKind>>(kind: K, ssa: &CoreSSA) -> Box<ApplyError> {
     Box::new(ApplyError {
         kind: kind.into(),
         ssa: ssa.clone(),
     })
 }
 
+pub(crate) fn tensor_constant<B: Backend>(
+    backend: &B,
+    args: Vec<Value<B>>, // must be empty
+    ssa: &CoreSSA,
+    c: &Constant,
+) -> Result<Vec<Value<B>>, Box<ApplyError>> {
+    if args.len() != 0 {
+        return Err(err(ApplyErrorKind::ArityError, ssa));
+    }
+
+    let tagged = match c {
+        Constant::F32(x) => TaggedNdArray::from_slice(backend, &[*x], super::Shape(vec![])),
+        Constant::U32(x) => TaggedNdArray::from_slice(backend, &[*x], super::Shape(vec![])),
+    }
+    .map_err(|e| err(e, ssa))?;
+
+    Ok(vec![Value::NdArray(tagged)])
+}
+
 pub(crate) fn tensor_scalar<B: Backend>(
     backend: &B,
     args: Vec<Value<B>>,
-    ssa: &SSA<Object, Operation>,
+    ssa: &CoreSSA,
 ) -> Result<Vec<Value<B>>, Box<ApplyError>> {
     if args.len() != 1 {
         return Err(err(ApplyErrorKind::ArityError, ssa));
@@ -72,7 +90,7 @@ pub(crate) fn tensor_scalar<B: Backend>(
 fn tensor_cast<B: Backend>(
     backend: &B,
     args: Vec<Value<B>>,
-    ssa: &SSA<Object, Operation>,
+    ssa: &CoreSSA,
 ) -> Result<Vec<Value<B>>, Box<ApplyError>> {
     if args.len() != 2 {
         return Err(Box::new(ApplyError {
@@ -105,7 +123,7 @@ fn tensor_cast<B: Backend>(
 fn tensor_sum<B: Backend>(
     backend: &B,
     args: Vec<Value<B>>,
-    ssa: &SSA<Object, Operation>,
+    ssa: &CoreSSA,
 ) -> Result<Vec<Value<B>>, Box<ApplyError>> {
     if args.len() != 1 {
         return Err(Box::new(ApplyError {
@@ -130,7 +148,7 @@ fn tensor_sum<B: Backend>(
 fn tensor_max<B: Backend>(
     backend: &B,
     args: Vec<Value<B>>,
-    ssa: &SSA<Object, Operation>,
+    ssa: &CoreSSA,
 ) -> Result<Vec<Value<B>>, Box<ApplyError>> {
     if args.len() != 1 {
         return Err(Box::new(ApplyError {
@@ -155,7 +173,7 @@ fn tensor_max<B: Backend>(
 fn tensor_reshape<B: Backend>(
     backend: &B,
     mut args: Vec<Value<B>>,
-    ssa: &SSA<Object, Operation>,
+    ssa: &CoreSSA,
 ) -> Result<Vec<Value<B>>, Box<ApplyError>> {
     if args.len() != 2 {
         return Err(Box::new(ApplyError {
@@ -179,7 +197,7 @@ fn tensor_reshape<B: Backend>(
 fn tensor_broadcast<B: Backend>(
     backend: &B,
     mut args: Vec<Value<B>>,
-    ssa: &SSA<Object, Operation>,
+    ssa: &CoreSSA,
 ) -> Result<Vec<Value<B>>, Box<ApplyError>> {
     if args.len() != 2 {
         return Err(Box::new(ApplyError {
@@ -202,7 +220,7 @@ fn tensor_broadcast<B: Backend>(
 fn tensor_arange<B: Backend>(
     backend: &B,
     args: Vec<Value<B>>,
-    ssa: &SSA<Object, Operation>,
+    ssa: &CoreSSA,
 ) -> Result<Vec<Value<B>>, Box<ApplyError>> {
     if args.len() != 1 {
         return Err(Box::new(ApplyError {
@@ -225,7 +243,7 @@ fn tensor_arange<B: Backend>(
 fn tensor_index<B: Backend>(
     backend: &B,
     mut args: Vec<Value<B>>,
-    ssa: &SSA<Object, Operation>,
+    ssa: &CoreSSA,
 ) -> Result<Vec<Value<B>>, Box<ApplyError>> {
     if args.len() != 3 {
         return Err(Box::new(ApplyError {
@@ -251,7 +269,7 @@ fn tensor_index<B: Backend>(
 fn tensor_concat<B: Backend>(
     backend: &B,
     mut args: Vec<Value<B>>,
-    ssa: &SSA<Object, Operation>,
+    ssa: &CoreSSA,
 ) -> Result<Vec<Value<B>>, Box<ApplyError>> {
     if args.len() != 3 {
         return Err(Box::new(ApplyError {
@@ -277,7 +295,7 @@ fn tensor_concat<B: Backend>(
 fn tensor_slice<B: Backend>(
     backend: &B,
     mut args: Vec<Value<B>>,
-    ssa: &SSA<Object, Operation>,
+    ssa: &CoreSSA,
 ) -> Result<Vec<Value<B>>, Box<ApplyError>> {
     if args.len() != 4 {
         return Err(Box::new(ApplyError {
@@ -312,7 +330,7 @@ type Unaryop<B: Backend> = fn(&B, TaggedNdArray<B>) -> TaggedNdArray<B>;
 fn binop<B: Backend>(
     backend: &B,
     args: Vec<Value<B>>,
-    ssa: &SSA<Object, Operation>,
+    ssa: &CoreSSA,
     callback: Binop<B>,
 ) -> Result<Vec<Value<B>>, Box<ApplyError>> {
     let args = try_into_tagged_ndarrays::<B, 2>(args, ssa)?;
@@ -323,7 +341,7 @@ fn binop<B: Backend>(
 fn unary_op<B: Backend>(
     backend: &B,
     args: Vec<Value<B>>,
-    ssa: &SSA<Object, Operation>,
+    ssa: &CoreSSA,
     callback: Unaryop<B>,
 ) -> Result<Vec<Value<B>>, Box<ApplyError>> {
     if args.len() != 1 {
@@ -350,7 +368,7 @@ fn unary_op<B: Backend>(
 /// Run an M → 1 op taking M NdArray values of the same dtype, producing an NdArray.
 fn run_op<B: Backend, F, const M: usize>(
     args: Vec<Value<B>>,
-    ssa: &SSA<Object, Operation>,
+    ssa: &CoreSSA,
     f: F,
 ) -> Result<Vec<Value<B>>, Box<ApplyError>>
 where
@@ -364,7 +382,7 @@ where
 /// Convert a Vec<Value<B>> into TaggedNdArrays<B, N> with compile-time length checking
 pub(crate) fn try_into_tagged_ndarrays<B: Backend, const N: usize>(
     values: Vec<Value<B>>,
-    ssa: &SSA<Object, Operation>,
+    ssa: &CoreSSA,
 ) -> Result<TaggedNdArrayTuple<B, N>, Box<ApplyError>> {
     let n = values.len();
 

--- a/catgrad-core/src/interpreter/tests.rs
+++ b/catgrad-core/src/interpreter/tests.rs
@@ -1,47 +1,8 @@
 //! Tests for the catgrad reference interpreter
 
+use super::TaggedNdArray;
 use super::backend::ndarray::NdArrayBackend;
-use super::{TaggedNdArray, Value, lit_to_value};
 use crate::category::core::Shape;
-use crate::category::lang::Literal;
-
-#[test]
-fn test_literal_u32_scalar() {
-    let literal = Literal::U32(42);
-    let result: Value<NdArrayBackend> = lit_to_value(&NdArrayBackend, &literal);
-
-    match result {
-        Value::NdArray(arr) => {
-            assert_eq!(arr.shape().0, vec![] as Vec<usize>);
-            match arr {
-                TaggedNdArray::U32([nd_arr]) => {
-                    assert_eq!(nd_arr[[]], 42);
-                }
-                _ => panic!("Expected U32 TaggedNdArray"),
-            }
-        }
-        _ => panic!("Expected NdArray value for U32 literal"),
-    }
-}
-
-#[test]
-fn test_literal_f32_scalar() {
-    let literal = Literal::F32(3.15);
-    let result: Value<NdArrayBackend> = lit_to_value(&NdArrayBackend, &literal);
-
-    match result {
-        Value::NdArray(arr) => {
-            assert_eq!(arr.shape().0, vec![] as Vec<usize>);
-            match arr {
-                TaggedNdArray::F32([nd_arr]) => {
-                    assert_eq!(nd_arr[[]], 3.15);
-                }
-                _ => panic!("Expected F32 TaggedNdArray"),
-            }
-        }
-        _ => panic!("Expected NdArray value for F32 literal"),
-    }
-}
 
 #[test]
 fn test_tagged_ndarray_constructors() {

--- a/catgrad-core/src/interpreter/types.rs
+++ b/catgrad-core/src/interpreter/types.rs
@@ -1,15 +1,20 @@
 //! Catgrad reference interpreter
 
-use crate::category::lang::*;
+use crate::category::core::{Dtype, Object, Operation};
 use crate::ssa::SSA;
 
 use super::backend::*;
 use crate::category::core::{NdArrayType, Shape};
 
+use crate::definition::Def;
+use crate::path::Path;
+
+pub(crate) type CoreSSA = SSA<Object, Def<Path, Operation>>;
+
 #[derive(Debug, Clone)]
 pub struct ApplyError {
     pub kind: ApplyErrorKind,
-    pub ssa: SSA<Object, Operation>,
+    pub ssa: CoreSSA,
 }
 
 #[derive(Debug, Clone)]

--- a/catgrad-core/src/pass/to_core.rs
+++ b/catgrad-core/src/pass/to_core.rs
@@ -2,11 +2,12 @@ use std::collections::HashMap;
 
 use crate::category::{core, lang};
 use crate::definition::Def;
+use crate::interpreter;
 
 /// Lower a `lang::Term` to a `core::Term`.
 /// If a Definition or Declaration was not a core operation, it is assumed to be a definition in
 /// [`core`].
-pub fn lang_to_core(term: lang::Term) -> core::Term {
+pub fn to_core(term: lang::Term) -> core::Term {
     let core_ops = core_declarations();
 
     term.map_edges(|e| match e {
@@ -26,6 +27,20 @@ pub fn lang_to_core(term: lang::Term) -> core::Term {
             lang::Literal::Dtype(d) => core::Operation::DtypeConstant(d),
         }),
     })
+}
+
+/// Lower an entire stdlib::Environment to the core, discarding type maps.
+pub fn env_to_core(env: crate::stdlib::Environment) -> interpreter::Environment {
+    let definitions = env
+        .definitions
+        .into_iter()
+        .map(|(k, v)| {
+            let v = crate::pass::to_core::to_core(v.term);
+            (k, v)
+        })
+        .collect();
+
+    interpreter::Environment { definitions }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/catgrad-core/src/prelude.rs
+++ b/catgrad-core/src/prelude.rs
@@ -1,4 +1,5 @@
 pub use crate::category::lang::*;
 pub use crate::check;
 pub use crate::interpreter;
+pub use crate::pass::to_core::to_core;
 pub use crate::stdlib::{Environment, FnModule, Module, nn, stdlib, to_load_ops};


### PR DESCRIPTION
... but keep old interface the same.
New functions:

- `Interpreter::run_core` - runs a lowered core term directly
- `Interpreter::from_core` - creates an interpreter from a core environment

The old functions `Interpreter::run` and `Interpreter::new` now do explicit lowering.