### PR TITLE
minor fixes to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,5 @@ Some features on the roadmap:
 [license_img]: https://img.shields.io/crates/l/catgrad.svg?style=for-the-badge "License badge"
 
 [catgrad_link]: https://catgrad.com
-[catgrad_img]: ./images/catgrad.svg
-
-[sigmoid_img]: ./images/sigmoid.svg
+[catgrad_img]: https://catgrad.com/catgrad.svg
+[sigmoid_img]: http://catgrad.com/sigmoid.svg

--- a/catgrad-legacy/src/backend/cpu/ndarray.rs
+++ b/catgrad-legacy/src/backend/cpu/ndarray.rs
@@ -265,7 +265,7 @@ impl<T: std::fmt::Display + Numeric> std::fmt::Display for NdArray<T> {
 }
 
 /// A disjoint union of typed arrays
-/// intuition: the "values" assigned to each node in a [`Term`].
+/// intuition: the "values" assigned to each node in a `Term`.
 #[derive(PartialEq, Debug, Clone)]
 pub enum TaggedNdArray {
     F16(NdArray<f16>),


### PR DESCRIPTION
Reference README images from catgrad.com so we can hotlink in rust docs.