### PR TITLE
Expose `normalize` function for typecheck::Type

### DIFF
--- a/catgrad/src/typecheck/interpreter.rs
+++ b/catgrad/src/typecheck/interpreter.rs
@@ -11,8 +11,20 @@ use crate::pass::to_core::Environment;
 
 use super::tensor_op::tensor_op;
 
-pub type Value = abstract_interpreter::Value<Interpreter>;
+pub(crate) type Value = abstract_interpreter::Value<Interpreter>;
 pub type ResultValues = abstract_interpreter::ResultValues<Interpreter>;
+pub type Type = abstract_interpreter::Value<Interpreter>;
+
+/// Compute the normal form for a [`Type`]
+pub fn normalize(v: Type) -> Type {
+    match v {
+        Type::Nat(n) => Type::Nat(n.nf()),
+        Type::Dtype(d) => Type::Dtype(d.nf()),
+        Type::Shape(s) => Type::Shape(s.nf()),
+        Type::Type(t) => Type::Type(t.nf()),
+        Type::Tensor(t) => Type::Tensor(t.nf()),
+    }
+}
 
 #[derive(Clone, std::fmt::Debug)]
 pub struct Interpreter {

--- a/catgrad/src/typecheck/mod.rs
+++ b/catgrad/src/typecheck/mod.rs
@@ -17,7 +17,6 @@ pub mod value_types;
 // public interface: value types and check function
 pub use crate::abstract_interpreter::InterpreterError;
 pub use check::{check, check_with};
+pub use interpreter::{Type, normalize};
 pub use parameters::Parameters;
 pub use value_types::{DtypeExpr, NatExpr, NdArrayType, ShapeExpr, TypeExpr};
-
-pub type Type = interpreter::Value;


### PR DESCRIPTION
Adds a `normalize` function to get normal forms for all types, and a couple small changes:

- Moves the `Type` alias into `typecheck::interpreter` instead of `mod.rs`
- exposes `Type, normalize` from `mod.rs`