### PR TITLE
Move interpreter::Parameters alias, use `tensor`

### DIFF
--- a/catgrad-llm/examples/llama.rs
+++ b/catgrad-llm/examples/llama.rs
@@ -669,9 +669,8 @@ fn load_model<B: interpreter::Backend>(
                 }
             };
 
-            let tensor =
-                interpreter::TaggedTensor::from_slice(backend, &data, Shape(shape.clone()))
-                    .expect("Failed to create tensor");
+            let tensor = interpreter::tensor(backend, Shape(shape.clone()), &data)
+                .expect("failed to create tensor");
             let key = path(name.split(".").collect()).expect("invalid param path");
             data_map.insert(key.clone(), tensor);
 

--- a/catgrad/examples/hidden.rs
+++ b/catgrad/examples/hidden.rs
@@ -206,9 +206,8 @@ fn load_param_data<B: interpreter::Backend>(backend: &B) -> interpreter::Paramet
     let layer1_data: Vec<f32> = (0..784 * 100)
         .map(|i| (i as f32 * 0.01 % 2.0) - 1.0) // Simple pattern: values between -1 and 1
         .collect();
-    let layer1_tensor =
-        interpreter::TaggedTensor::from_slice(backend, &layer1_data, Shape(vec![784, 100]))
-            .expect("Failed to create layer1 tensor");
+    let layer1_tensor = interpreter::tensor(backend, Shape(vec![784, 100]), &layer1_data)
+        .expect("failed to create tensor");
     map.insert(
         path(vec!["0", "weights"]).expect("invalid param path"),
         layer1_tensor,
@@ -218,9 +217,8 @@ fn load_param_data<B: interpreter::Backend>(backend: &B) -> interpreter::Paramet
     let layer2_data: Vec<f32> = (0..100 * 10)
         .map(|i| (i as f32 * 0.01 % 2.0) - 1.0)
         .collect();
-    let layer2_tensor =
-        interpreter::TaggedTensor::from_slice(backend, &layer2_data, Shape(vec![100, 10]))
-            .expect("Failed to create layer2 tensor");
+    let layer2_tensor = interpreter::tensor(backend, Shape(vec![100, 10]), &layer2_data)
+        .expect("failed to create tensor");
     map.insert(
         path(vec!["1", "weights"]).expect("invalid param path"),
         layer2_tensor,

--- a/catgrad/src/interpreter/interpreter.rs
+++ b/catgrad/src/interpreter/interpreter.rs
@@ -1,5 +1,4 @@
 use super::backend::Backend;
-use super::parameters::Parameters;
 use super::tensor_op::tensor_op;
 use super::types::*;
 

--- a/catgrad/src/interpreter/mod.rs
+++ b/catgrad/src/interpreter/mod.rs
@@ -7,12 +7,11 @@ pub mod interpreter;
 pub use interpreter::*;
 
 pub mod backend;
-pub mod parameters;
+//pub mod parameters;
 pub mod tensor_op;
 
 pub use crate::category::core::Shape;
 pub use backend::{Backend, BackendError};
-pub use parameters::Parameters;
 
 #[cfg(all(test, feature = "ndarray-backend"))]
 mod tests;

--- a/catgrad/src/interpreter/types.rs
+++ b/catgrad/src/interpreter/types.rs
@@ -7,6 +7,7 @@ use crate::category::core::{Dtype, Shape};
 
 pub type Value<B> = abstract_interpreter::Value<Interpreter<B>>;
 pub type ResultValues<B> = abstract_interpreter::ResultValues<Interpreter<B>>;
+pub type Parameters<B> = abstract_interpreter::parameters::Parameters<Interpreter<B>>;
 
 ////////////////////////////////////////////////////////////////////////////////
 // Multiple tagged ndarrays


### PR DESCRIPTION
Two main (related) changes:

- The `interpreter` helper struct `Parameters` is now declared as a type alias in `interpreter/types.rs`
- Its associated helper "From" instance is completely removed, now relying on the one exported from `abstract_interpreter`
- This breaks the use of `TaggedTensor::from_slice` in examples, which are now replaced with the `tensor` helper