### PR TITLE
MLIR tensor_slice start index fix

### DIFF
--- a/catgrad-mlir/src/lower/ops.rs
+++ b/catgrad-mlir/src/lower/ops.rs
@@ -1119,7 +1119,7 @@ pub fn tensor_slice(ssa: &SSA<Type, lang::Operation>) -> Vec<grammar::Statement>
             if i == static_dim {
                 format!("{start}")
             } else {
-                format!("{base}_c{i}")
+                format!("{base}_c0")
             }
         })
         .collect::<Vec<_>>()


### PR DESCRIPTION
Start index start should be 0 for all but the selected slicing dim.