### PR TITLE
Make rmsnorm work with different dimensions.

### DIFF
--- a/catgrad-llm/src/helpers.rs
+++ b/catgrad-llm/src/helpers.rs
@@ -117,9 +117,10 @@ pub fn layernorm(builder: &Builder, eps: f32, p: Path, x: Var) -> Var {
     lr + beta
 }
 
-pub fn rmsnorm_raw(builder: &Builder, eps: f32, x: Var) -> Var {
+pub fn rmsnorm_raw<const N: usize>(builder: &Builder, eps: f32, x: Var) -> Var {
     let x_shape = shape(builder, x.clone());
-    let [_, _, n] = unpack::<3>(builder, x_shape.clone());
+    let u = unpack::<N>(builder, x_shape.clone());
+    let n = u[N - 1].clone();
     let s = sum(builder, x.clone() * x.clone());
 
     let constn = nat_to_u32(builder, n);
@@ -136,9 +137,9 @@ pub fn rmsnorm_raw(builder: &Builder, eps: f32, x: Var) -> Var {
 }
 
 // rmsnorm(x) = x / √(E[x²] + ε) × γ
-pub fn rmsnorm(builder: &Builder, eps: f32, p: Path, x: Var) -> Var {
+pub fn rmsnorm<const N: usize>(builder: &Builder, eps: f32, p: Path, x: Var) -> Var {
     let gamma = param(builder, &p.extend(["weight"]).unwrap());
-    let lr = rmsnorm_raw(builder, eps, x);
+    let lr = rmsnorm_raw::<N>(builder, eps, x);
     let lr_shape = shape(builder, lr.clone());
     let gamma = broadcast(builder, gamma, lr_shape);
     lr * gamma

--- a/catgrad-llm/src/models/deepseek.rs
+++ b/catgrad-llm/src/models/deepseek.rs
@@ -189,7 +189,7 @@ impl DeepSeekModel {
             p.extend(["q_a_proj"]).unwrap(),
             x.clone(),
         );
-        let q = rmsnorm(
+        let q = rmsnorm::<3>(
             builder,
             self.config.rms_norm_eps,
             p.extend(["q_a_layernorm"]).unwrap(),
@@ -235,7 +235,7 @@ impl DeepSeekModel {
         let k_pass = kp_split[0].clone();
         let k_rot = kp_split[1].clone();
 
-        let k_pass = rmsnorm(
+        let k_pass = rmsnorm::<3>(
             builder,
             self.config.rms_norm_eps,
             p.extend(["kv_a_layernorm"]).unwrap(),
@@ -336,7 +336,7 @@ impl DeepSeekModel {
         x: Var,
     ) -> Var {
         let res = x.clone();
-        let x = rmsnorm(
+        let x = rmsnorm::<3>(
             builder,
             self.config.rms_norm_eps,
             p.extend(["input_layernorm"]).unwrap(),
@@ -353,7 +353,7 @@ impl DeepSeekModel {
 
         let x = res + x;
         let res = x.clone();
-        let x = rmsnorm(
+        let x = rmsnorm::<3>(
             builder,
             self.config.rms_norm_eps,
             p.extend(["post_attention_layernorm"]).unwrap(),
@@ -395,7 +395,7 @@ impl Module<1, 1> for DeepSeekModel {
             );
         }
 
-        x = rmsnorm(
+        x = rmsnorm::<3>(
             builder,
             self.config.rms_norm_eps,
             root.extend(["model", "norm"]).unwrap(),

--- a/catgrad-llm/src/models/granite.rs
+++ b/catgrad-llm/src/models/granite.rs
@@ -179,7 +179,7 @@ impl GraniteModel {
         x: Var,
     ) -> Var {
         let res = x.clone();
-        let x = rmsnorm(
+        let x = rmsnorm::<3>(
             builder,
             self.config.rms_norm_eps,
             p.extend(["input_layernorm"]).unwrap(),
@@ -199,7 +199,7 @@ impl GraniteModel {
 
         let x = res + x * mul.clone();
         let res = x.clone();
-        let x = rmsnorm(
+        let x = rmsnorm::<3>(
             builder,
             self.config.rms_norm_eps,
             p.extend(["post_attention_layernorm"]).unwrap(),
@@ -245,7 +245,7 @@ impl Module<1, 1> for GraniteModel {
             );
         }
 
-        x = rmsnorm(
+        x = rmsnorm::<3>(
             builder,
             self.config.rms_norm_eps,
             root.extend(["model", "norm"]).unwrap(),

--- a/catgrad-llm/src/models/llama.rs
+++ b/catgrad-llm/src/models/llama.rs
@@ -124,7 +124,7 @@ impl LlamaModel {
         x: Var,
     ) -> Var {
         let res = x.clone();
-        let x = rmsnorm(
+        let x = rmsnorm::<3>(
             builder,
             self.config.rms_norm_eps,
             p.extend(["input_layernorm"]).unwrap(),
@@ -140,7 +140,7 @@ impl LlamaModel {
         );
         let x = res + x;
         let res = x.clone();
-        let x = rmsnorm(
+        let x = rmsnorm::<3>(
             builder,
             self.config.rms_norm_eps,
             p.extend(["post_attention_layernorm"]).unwrap(),
@@ -178,7 +178,7 @@ impl Module<1, 1> for LlamaModel {
             );
         }
 
-        x = rmsnorm(
+        x = rmsnorm::<3>(
             builder,
             self.config.rms_norm_eps,
             root.extend(["model", "norm"]).unwrap(),


### PR DESCRIPTION
RMSNorm can be used on inputs of different ranks and it needs to get the last dimension value in order to compute mean.
To avoid duplicating it in qwen and other models that use qk-norm in the attention block, this PR makes it use a const generic.