### PR TITLE
Siglip simplify

### DIFF
--- a/catgrad-llm/Cargo.toml
+++ b/catgrad-llm/Cargo.toml
@@ -26,6 +26,7 @@ log = "0.4.27"
 half = { workspace = true }
 thiserror = "2.0"
 rayon = "1.11.0"
+image = "0.25.6"
 
 
 [dev-dependencies]
@@ -35,6 +36,5 @@ graphviz-rust = "0.9.5"
 open-hypergraphs-dot = "0.2.1"
 env_logger = "0.11"
 test-log = "0.2.17"
-image = "0.25.6"
 catgrad = {path = "../catgrad", features=["ndarray-backend", "candle-backend", "svg", "serde"]}
 anyhow = "1.0.99"

--- a/catgrad-llm/src/utils.rs
+++ b/catgrad-llm/src/utils.rs
@@ -489,3 +489,39 @@ pub fn load_model<B: interpreter::Backend>(
         total_params,
     ))
 }
+
+// Loads the image and returns flattened data + shape
+pub fn load_and_preprocess_image(
+    image_path: &PathBuf,
+    image_size: usize,
+    patch_size: usize,
+) -> (Vec<f32>, Vec<usize>) {
+    let num_channels = 3;
+
+    let img = image::open(image_path).unwrap();
+    let resized_img = img.resize_to_fill(
+        image_size as u32,
+        image_size as u32,
+        image::imageops::FilterType::Triangle,
+    );
+    let rgb_img = resized_img.to_rgb8();
+    let img = rgb_img.into_raw();
+
+    let pixels: Vec<f32> = img.iter().map(|&x| x as f32 * (2. / 255.0) - 1.).collect();
+    // For image sizes 384x384 we need to truncate to 378x378 so it's a multiple of patch size.
+    let aligned_image_size = (image_size / patch_size) * patch_size;
+    let mut patches = vec![0.0; num_channels * aligned_image_size * aligned_image_size];
+    for row in 0..aligned_image_size {
+        for col in 0..aligned_image_size {
+            for chan in 0..num_channels {
+                patches[chan * aligned_image_size * aligned_image_size
+                    + row * aligned_image_size
+                    + col] = pixels[(row * image_size + col) * num_channels + chan];
+            }
+        }
+    }
+    (
+        patches,
+        vec![1, num_channels, aligned_image_size, aligned_image_size],
+    )
+}


### PR DESCRIPTION
Remove unused bits, rework patch embeddings and preprocess function, move the latter to the lib (needed by VLMs too).