### PR TITLE
WIP: new module sig

### DIFF
--- a/catgrad-llm/examples/llama/main.rs
+++ b/catgrad-llm/examples/llama/main.rs
@@ -220,7 +220,7 @@ fn run_with_backend<B: interpreter::Backend>(
     let mut start_gen = std::time::Instant::now();
     let mut elapsed_pp = std::time::Duration::ZERO;
     let interpreter = interpreter::Interpreter::new(backend, env, parameter_values);
-    let empty_cache = empty_kv_cache(&interpreter.backend, model.config())?;
+    let empty_cache = empty_cache(&interpreter.backend, model.config())?;
     let eos_token_ids = model.config().get_eos_token_ids();
     let mut kv_cache = empty_cache.clone();
 
@@ -284,12 +284,18 @@ fn run_with_backend<B: interpreter::Backend>(
     Ok(())
 }
 
-type KvCache<B> = (interpreter::Value<B>, interpreter::Value<B>);
+// Holds KV cache and optionally other state cache (for non-attention layers)
+#[derive(Debug, Clone)]
+struct LLMCache<B: interpreter::Backend> {
+    k: interpreter::Value<B>,
+    v: interpreter::Value<B>,
+    state: interpreter::Value<B>,
+}
 
-fn empty_kv_cache<B: interpreter::Backend>(
+fn empty_cache<B: interpreter::Backend>(
     backend: &B,
     config: &dyn LLMConfig,
-) -> Result<KvCache<B>> {
+) -> Result<LLMCache<B>> {
     let k_shape = Shape(vec![
         config.num_hidden_layers(),
         1,
@@ -308,15 +314,24 @@ fn empty_kv_cache<B: interpreter::Backend>(
         .map_err(|err| anyhow::anyhow!("kv cache tensor error: {:?}", err))?;
     let v = interpreter::tensor(backend, v_shape, Vec::<f32>::new())
         .map_err(|err| anyhow::anyhow!("kv cache tensor error: {:?}", err))?;
-    Ok((k, v))
+
+    let unused_shape = Shape(vec![1, 0]);
+    let unused = interpreter::tensor(backend, unused_shape, Vec::<f32>::new())
+        .map_err(|err| anyhow::anyhow!("unused tensor error: {:?}", err))?;
+
+    Ok(LLMCache {
+        k,
+        v,
+        state: unused,
+    })
 }
 
 fn run_interpreter<B: interpreter::Backend>(
     typed_term: &TypedTerm,
     interpreter: &interpreter::Interpreter<B>,
     input_data: &[u32],
-    kv_cache: &KvCache<B>,
-) -> Result<(u32, KvCache<B>)> {
+    llm_cache: &LLMCache<B>,
+) -> Result<(u32, LLMCache<B>)> {
     let input_tensor = interpreter::tensor(
         &interpreter.backend,
         Shape(vec![1, input_data.len()]),
@@ -328,10 +343,18 @@ fn run_interpreter<B: interpreter::Backend>(
     let mut results = interpreter
         .run(
             typed_term.term.clone(),
-            vec![input_tensor, kv_cache.0.clone(), kv_cache.1.clone()],
+            vec![
+                input_tensor,
+                llm_cache.k.clone(),
+                llm_cache.v.clone(),
+                llm_cache.state.clone(),
+            ],
         )
         .expect("Failed to run inference");
 
+    let out_state = results
+        .pop()
+        .ok_or_else(|| anyhow::anyhow!("No state output"))?;
     let out_v = results
         .pop()
         .ok_or_else(|| anyhow::anyhow!("No KV cache V output"))?;
@@ -341,7 +364,14 @@ fn run_interpreter<B: interpreter::Backend>(
     if let Some(output) = results.pop() {
         match output {
             interpreter::Value::Tensor(arr) => match interpreter.backend.to_vec(arr) {
-                interpreter::TaggedVec::U32(v) => Ok((v[v.len() - 1], (out_k, out_v))),
+                interpreter::TaggedVec::U32(v) => Ok((
+                    v[v.len() - 1],
+                    LLMCache {
+                        k: out_k,
+                        v: out_v,
+                        state: out_state,
+                    },
+                )),
                 _ => Err(anyhow::anyhow!("Unexpected output dtype")),
             },
             t => Err(anyhow::anyhow!("Output was not a tensor: {:?}", t)),

--- a/catgrad-llm/src/helpers.rs
+++ b/catgrad-llm/src/helpers.rs
@@ -4,7 +4,7 @@ use catgrad::prelude::*;
 use catgrad::stdlib::nn::*;
 
 /// Type signature for LLM Modules
-pub fn llm_type(config: &dyn LLMConfig) -> ([Type; 3], [Type; 3]) {
+pub fn llm_type(config: &dyn LLMConfig) -> ([Type; 4], [Type; 4]) {
     use catgrad::typecheck::*;
     let batch_size = NatExpr::Var(0);
     let seq_len = NatExpr::Var(1);
@@ -65,14 +65,22 @@ pub fn llm_type(config: &dyn LLMConfig) -> ([Type; 3], [Type; 3]) {
         dtype: DtypeExpr::Constant(Dtype::F32),
         shape: ShapeExpr::Shape(vec![
             num_layers,
-            batch_size,
+            batch_size.clone(),
             num_kv_heads,
             out_cache_len,
             NatExpr::Constant(config.get_v_head_dim()),
         ]),
     }));
 
-    ([t_x, t_k, t_v], [t_y, t_k_out, t_v_out])
+    let t_unused = Type::Tensor(TypeExpr::NdArrayType(NdArrayType {
+        dtype: DtypeExpr::Constant(Dtype::F32),
+        shape: ShapeExpr::Shape(vec![batch_size.clone(), batch_size]),
+    }));
+
+    (
+        [t_x, t_k, t_v, t_unused.clone()],
+        [t_y, t_k_out, t_v_out, t_unused],
+    )
 }
 
 pub struct Cache {
@@ -80,6 +88,7 @@ pub struct Cache {
     pub sin: Var,
     pub in_kv_cache: Vec<(Var, Var)>,
     pub out_kv_cache: Vec<(Var, Var)>,
+    // pub conv_state: Vec<Var>,
 }
 
 impl Cache {
@@ -632,7 +641,7 @@ pub enum WeightPostProcess {
     ConcatMoeExperts { num_local_experts: usize },
 }
 
-pub trait LLMModel: Module<3, 3> {
+pub trait LLMModel: Module<4, 4> {
     fn config(&self) -> &dyn LLMConfig;
 
     fn weight_post_process(&self) -> WeightPostProcess {

--- a/catgrad-llm/src/models/deepseek.rs
+++ b/catgrad-llm/src/models/deepseek.rs
@@ -484,12 +484,12 @@ impl DeepSeekModel {
     }
 }
 
-impl Module<3, 3> for DeepSeekModel {
+impl Module<4, 4> for DeepSeekModel {
     fn path(&self) -> Path {
         path(vec!["deepseek"]).expect("invalid model path")
     }
 
-    fn def(&self, builder: &Builder, [x, in_k, in_v]: [Var; 3]) -> [Var; 3] {
+    fn def(&self, builder: &Builder, [x, in_k, in_v, unused]: [Var; 4]) -> [Var; 4] {
         let root = self.path();
 
         let mut cache = Cache::init(
@@ -544,10 +544,10 @@ impl Module<3, 3> for DeepSeekModel {
 
         x = argmax(builder, x);
         let (out_k, out_v) = cache.get_kv_cache(builder);
-        [x, out_k, out_v]
+        [x, out_k, out_v, unused]
     }
 
-    fn ty(&self) -> ([Type; 3], [Type; 3]) {
+    fn ty(&self) -> ([Type; 4], [Type; 4]) {
         llm_type(&self.config)
     }
 }

--- a/catgrad-llm/src/models/gemma3.rs
+++ b/catgrad-llm/src/models/gemma3.rs
@@ -555,22 +555,28 @@ impl Gemma3Model {
     }
 }
 
-impl Module<3, 3> for Gemma3Model {
+impl Module<4, 4> for Gemma3Model {
     fn path(&self) -> Path {
         path(vec!["gemma3"]).expect("invalid model path")
     }
 
-    fn def(&self, builder: &Builder, [x, in_k, in_v]: [Var; 3]) -> [Var; 3] {
+    fn def(&self, builder: &Builder, [x, in_k, in_v, unused]: [Var; 4]) -> [Var; 4] {
         let mut root = self.path();
         if !self.root.is_empty() {
             root = root
                 .extend(self.root.split('.').collect::<Vec<&str>>())
                 .unwrap();
         }
-        self.forward(builder, root, x, in_k, in_v)
+        let result = self.forward(builder, root, x, in_k, in_v);
+        [
+            result[0].clone(),
+            result[1].clone(),
+            result[2].clone(),
+            unused,
+        ]
     }
 
-    fn ty(&self) -> ([Type; 3], [Type; 3]) {
+    fn ty(&self) -> ([Type; 4], [Type; 4]) {
         llm_type(&self.config)
     }
 }

--- a/catgrad-llm/src/models/gpt2.rs
+++ b/catgrad-llm/src/models/gpt2.rs
@@ -189,12 +189,12 @@ impl GPT2Model {
 }
 
 // Implement `Def`: this is like torch's `Module`.
-impl Module<3, 3> for GPT2Model {
+impl Module<4, 4> for GPT2Model {
     fn path(&self) -> Path {
         path(vec!["gpt2"]).expect("invalid model path")
     }
 
-    fn def(&self, builder: &Builder, [x, in_k, in_v]: [Var; 3]) -> [Var; 3] {
+    fn def(&self, builder: &Builder, [x, in_k, in_v, unused]: [Var; 4]) -> [Var; 4] {
         let root = self.path();
 
         let [_, _, _, cache_len, _] = unpack::<5>(builder, shape(builder, in_k.clone()));
@@ -232,11 +232,11 @@ impl Module<3, 3> for GPT2Model {
 
         x = argmax(builder, x);
         let (out_k, out_v) = cache.get_kv_cache(builder);
-        [x, out_k, out_v]
+        [x, out_k, out_v, unused]
     }
 
     // This should return the *detailed* type of the model
-    fn ty(&self) -> ([Type; 3], [Type; 3]) {
+    fn ty(&self) -> ([Type; 4], [Type; 4]) {
         llm_type(&self.config)
     }
 }

--- a/catgrad-llm/src/models/gpt_oss.rs
+++ b/catgrad-llm/src/models/gpt_oss.rs
@@ -300,12 +300,12 @@ impl GPTOssModel {
     }
 }
 
-impl Module<3, 3> for GPTOssModel {
+impl Module<4, 4> for GPTOssModel {
     fn path(&self) -> Path {
         path(vec!["gpt_oss"]).expect("invalid model path")
     }
 
-    fn def(&self, builder: &Builder, [x, in_k, in_v]: [Var; 3]) -> [Var; 3] {
+    fn def(&self, builder: &Builder, [x, in_k, in_v, unused]: [Var; 4]) -> [Var; 4] {
         let root = self.path();
 
         let mut cache = Cache::init(
@@ -360,10 +360,10 @@ impl Module<3, 3> for GPTOssModel {
 
         x = argmax(builder, x);
         let (out_k, out_v) = cache.get_kv_cache(builder);
-        [x, out_k, out_v]
+        [x, out_k, out_v, unused]
     }
 
-    fn ty(&self) -> ([Type; 3], [Type; 3]) {
+    fn ty(&self) -> ([Type; 4], [Type; 4]) {
         llm_type(&self.config)
     }
 }

--- a/catgrad-llm/src/models/granite.rs
+++ b/catgrad-llm/src/models/granite.rs
@@ -319,12 +319,12 @@ impl GraniteModel {
     }
 }
 
-impl Module<3, 3> for GraniteModel {
+impl Module<4, 4> for GraniteModel {
     fn path(&self) -> Path {
         path(vec!["granite"]).expect("invalid model path")
     }
 
-    fn def(&self, builder: &Builder, [x, in_k, in_v]: [Var; 3]) -> [Var; 3] {
+    fn def(&self, builder: &Builder, [x, in_k, in_v, unused]: [Var; 4]) -> [Var; 4] {
         let root = self.path();
 
         let mut cache = Cache::init(
@@ -377,11 +377,11 @@ impl Module<3, 3> for GraniteModel {
 
         x = argmax(builder, x);
         let (out_k, out_v) = cache.get_kv_cache(builder);
-        [x, out_k, out_v]
+        [x, out_k, out_v, unused]
     }
 
     // This should return the *detailed* type of the model
-    fn ty(&self) -> ([Type; 3], [Type; 3]) {
+    fn ty(&self) -> ([Type; 4], [Type; 4]) {
         llm_type(&self.config)
     }
 }

--- a/catgrad-llm/src/models/lfm2.rs
+++ b/catgrad-llm/src/models/lfm2.rs
@@ -365,12 +365,12 @@ impl Lfm2Model {
     }
 }
 
-impl Module<3, 3> for Lfm2Model {
+impl Module<4, 4> for Lfm2Model {
     fn path(&self) -> Path {
         path(vec!["lfm2"]).expect("invalid model path")
     }
 
-    fn def(&self, builder: &Builder, [x, in_k, in_v]: [Var; 3]) -> [Var; 3] {
+    fn def(&self, builder: &Builder, [x, in_k, in_v, conv_state]: [Var; 4]) -> [Var; 4] {
         let root = self.path();
 
         let mut cache = Cache::init(
@@ -419,10 +419,28 @@ impl Module<3, 3> for Lfm2Model {
 
         x = argmax(builder, x);
         let (out_k, out_v) = cache.get_kv_cache(builder);
-        [x, out_k, out_v]
+        [x, out_k, out_v, conv_state]
     }
 
-    fn ty(&self) -> ([Type; 3], [Type; 3]) {
-        llm_type(&self.config)
+    // This adds a conv state to both inputs and outputs
+    fn ty(&self) -> ([Type; 4], [Type; 4]) {
+        use catgrad::typecheck::*;
+
+        let batch_size = NatExpr::Var(0);
+        let hidden_size = NatExpr::Constant(self.config.hidden_size);
+        let conv_size = NatExpr::Constant(self.config.conv_l_cache);
+
+        // The conv state is batch_size × hidden_size x conv_size
+        let t_conv_state = Type::Tensor(TypeExpr::NdArrayType(NdArrayType {
+            dtype: DtypeExpr::Constant(Dtype::U32),
+            shape: ShapeExpr::Shape(vec![batch_size, hidden_size, conv_size]),
+        }));
+
+        let ([tx, tk_in, tv_in, _], [ty, tk_out, tv_out, _]) = llm_type(&self.config);
+
+        (
+            [tx, tk_in, tv_in, t_conv_state.clone()],
+            [ty, tk_out, tv_out, t_conv_state],
+        )
     }
 }

--- a/catgrad-llm/src/models/llama.rs
+++ b/catgrad-llm/src/models/llama.rs
@@ -241,12 +241,12 @@ impl LlamaModel {
     }
 }
 
-impl Module<3, 3> for LlamaModel {
+impl Module<4, 4> for LlamaModel {
     fn path(&self) -> Path {
         path(vec!["llama"]).expect("invalid model path")
     }
 
-    fn def(&self, builder: &Builder, [x, in_k, in_v]: [Var; 3]) -> [Var; 3] {
+    fn def(&self, builder: &Builder, [x, in_k, in_v, unused]: [Var; 4]) -> [Var; 4] {
         let mut root = self.path();
         if !self.root.is_empty() {
             root = root
@@ -307,11 +307,11 @@ impl Module<3, 3> for LlamaModel {
 
         x = argmax(builder, x);
         let (out_k, out_v) = cache.get_kv_cache(builder);
-        [x, out_k, out_v]
+        [x, out_k, out_v, unused]
     }
 
     // This should return the *detailed* type of the model
-    fn ty(&self) -> ([Type; 3], [Type; 3]) {
+    fn ty(&self) -> ([Type; 4], [Type; 4]) {
         llm_type(&self.config)
     }
 }

--- a/catgrad-llm/src/models/mistral3.rs
+++ b/catgrad-llm/src/models/mistral3.rs
@@ -267,12 +267,12 @@ impl Mistral3Model {
     }
 }
 
-impl Module<3, 3> for Mistral3Model {
+impl Module<4, 4> for Mistral3Model {
     fn path(&self) -> Path {
         path(vec!["mistral3"]).expect("invalid model path")
     }
 
-    fn def(&self, builder: &Builder, [x, in_k, in_v]: [Var; 3]) -> [Var; 3] {
+    fn def(&self, builder: &Builder, [x, in_k, in_v, unused]: [Var; 4]) -> [Var; 4] {
         let mut root = self.path();
         if !self.root.is_empty() {
             root = root
@@ -333,10 +333,10 @@ impl Module<3, 3> for Mistral3Model {
 
         x = argmax(builder, x);
         let (out_k, out_v) = cache.get_kv_cache(builder);
-        [x, out_k, out_v]
+        [x, out_k, out_v, unused]
     }
 
-    fn ty(&self) -> ([Type; 3], [Type; 3]) {
+    fn ty(&self) -> ([Type; 4], [Type; 4]) {
         llm_type(&self.config)
     }
 }

--- a/catgrad-llm/src/models/olmo.rs
+++ b/catgrad-llm/src/models/olmo.rs
@@ -246,12 +246,12 @@ impl OlmoModel {
     }
 }
 
-impl Module<3, 3> for OlmoModel {
+impl Module<4, 4> for OlmoModel {
     fn path(&self) -> Path {
         path(vec!["olmo"]).expect("invalid model path")
     }
 
-    fn def(&self, builder: &Builder, [x, in_k, in_v]: [Var; 3]) -> [Var; 3] {
+    fn def(&self, builder: &Builder, [x, in_k, in_v, unused]: [Var; 4]) -> [Var; 4] {
         let root = self.path();
 
         let mut cache = Cache::init(
@@ -306,11 +306,11 @@ impl Module<3, 3> for OlmoModel {
 
         x = argmax(builder, x);
         let (out_k, out_v) = cache.get_kv_cache(builder);
-        [x, out_k, out_v]
+        [x, out_k, out_v, unused]
     }
 
     // This should return the *detailed* type of the model
-    fn ty(&self) -> ([Type; 3], [Type; 3]) {
+    fn ty(&self) -> ([Type; 4], [Type; 4]) {
         llm_type(&self.config)
     }
 }

--- a/catgrad-llm/src/models/phi3.rs
+++ b/catgrad-llm/src/models/phi3.rs
@@ -251,12 +251,12 @@ impl Phi3Model {
     }
 }
 
-impl Module<3, 3> for Phi3Model {
+impl Module<4, 4> for Phi3Model {
     fn path(&self) -> Path {
         path(vec!["phi3"]).expect("invalid model path")
     }
 
-    fn def(&self, builder: &Builder, [x, in_k, in_v]: [Var; 3]) -> [Var; 3] {
+    fn def(&self, builder: &Builder, [x, in_k, in_v, unused]: [Var; 4]) -> [Var; 4] {
         let root = self.path();
 
         let mut cache = Cache::init(
@@ -311,11 +311,11 @@ impl Module<3, 3> for Phi3Model {
 
         x = argmax(builder, x);
         let (out_k, out_v) = cache.get_kv_cache(builder);
-        [x, out_k, out_v]
+        [x, out_k, out_v, unused]
     }
 
     // This should return the *detailed* type of the model
-    fn ty(&self) -> ([Type; 3], [Type; 3]) {
+    fn ty(&self) -> ([Type; 4], [Type; 4]) {
         llm_type(&self.config)
     }
 }

--- a/catgrad-llm/src/models/qwen3.rs
+++ b/catgrad-llm/src/models/qwen3.rs
@@ -365,12 +365,12 @@ impl Qwen3Model {
     }
 }
 
-impl Module<3, 3> for Qwen3Model {
+impl Module<4, 4> for Qwen3Model {
     fn path(&self) -> Path {
         path(vec!["qwen3"]).expect("invalid model path")
     }
 
-    fn def(&self, builder: &Builder, [x, in_k, in_v]: [Var; 3]) -> [Var; 3] {
+    fn def(&self, builder: &Builder, [x, in_k, in_v, unused]: [Var; 4]) -> [Var; 4] {
         let root = self.path();
 
         let mut cache = Cache::init(
@@ -425,11 +425,11 @@ impl Module<3, 3> for Qwen3Model {
 
         x = argmax(builder, x);
         let (out_k, out_v) = cache.get_kv_cache(builder);
-        [x, out_k, out_v]
+        [x, out_k, out_v, unused]
     }
 
     // This should return the *detailed* type of the model
-    fn ty(&self) -> ([Type; 3], [Type; 3]) {
+    fn ty(&self) -> ([Type; 4], [Type; 4]) {
         llm_type(&self.config)
     }
 }


### PR DESCRIPTION
Hybrid models need threading the state for the linear attention layers through the graph, as done with KV-caches.
This means they need more input-output pairs for the graph - for example LFM needs 4 inputs and outputs.

@statusfailed in order to treat all models uniformly in the calling code I came up with all models implementing Module<4,4> and the attention only models ignore that extra input. It's not too elegant though, any thoughts?

Since Module has a strict type using arrays not vectors, when the term is called it needs that many inputs. Maybe there's a way to  convince Rust to go through an extra trait instead of the current LLMConfig (which is used for trait objects). Maybe with generics and more boilerplate this too can be done differently.