### PR TITLE
Thinking mode

### DIFF
--- a/catgrad-llm/examples/llama/main.rs
+++ b/catgrad-llm/examples/llama/main.rs
@@ -43,6 +43,9 @@ struct Args {
     /// Pass raw prompt without chat template
     #[arg(long)]
     raw: bool,
+    /// Thinking mode
+    #[arg(long)]
+    thinking: bool,
     /// Tokens to generate
     #[arg(short = 's', long, default_value_t = 1)]
     max_seq_len: usize,
@@ -211,7 +214,7 @@ fn run_with_backend<B: interpreter::Backend>(
             &tokenizer_config,
             &args.prompt,
             use_image,
-            false,
+            args.thinking,
         )?
     };
 

--- a/catgrad-llm/examples/serve.rs
+++ b/catgrad-llm/examples/serve.rs
@@ -233,6 +233,9 @@ where
 fn serve_openai(request: Request, engine: &InferenceEngine, req: openai::ChatCompletionRequest) {
     let model = engine.model_name.clone();
     let max_tokens = req.max_tokens;
+    let enable_thinking = req
+        .reasoning_effort
+        .is_some_and(|effort| effort != openai::ReasoningEffort::None);
     let stream = req.stream == Some(true);
     let stream_include_usage = req
         .stream_options
@@ -244,7 +247,10 @@ fn serve_openai(request: Request, engine: &InferenceEngine, req: openai::ChatCom
         .into_iter()
         .map(|m| types::Message::OpenAI(Box::new(m)))
         .collect();
-    let prepared = match engine.engine.prepare_messages(&messages) {
+    let prepared = match engine
+        .engine
+        .prepare_messages_with_thinking(&messages, enable_thinking)
+    {
         Ok(prepared) => prepared,
         Err(err) => {
             respond_llm_error(request, err);

--- a/catgrad-llm/src/run.rs
+++ b/catgrad-llm/src/run.rs
@@ -13,7 +13,7 @@ use crate::types;
 use crate::utils::{
     empty_state_cache, get_model, get_model_chat_template, interpolate_multimodal_prompt,
     load_model, post_process_model_weights, prepare_multimodal_input,
-    prepare_multimodal_input_from_bytes, render_chat_prompt, split_image_tokens,
+    prepare_multimodal_input_from_bytes, render_chat_prompt_with_thinking, split_image_tokens,
 };
 use crate::{Detokenizer, LLMError, PreparedPrompt, Result};
 use catgrad::interpreter::backend::candle::CandleBackend;
@@ -170,11 +170,23 @@ impl ModelEngine {
     /// The engine does not retain chat history. To continue a conversation, pass the full message
     /// history you want rendered into the prompt.
     pub fn prepare_messages(&self, messages: &[types::Message]) -> Result<PreparedPrompt> {
+        self.prepare_messages_with_thinking(messages, false)
+    }
+
+    /// Renders chat messages with the model chat template and tokenizes the result.
+    ///
+    /// Set `enable_thinking` for chat templates that expose a corresponding template flag.
+    pub fn prepare_messages_with_thinking(
+        &self,
+        messages: &[types::Message],
+        enable_thinking: bool,
+    ) -> Result<PreparedPrompt> {
         let multimodal = self.prepare_multimodal_messages(messages)?;
-        let prompt = render_chat_prompt(
+        let prompt = render_chat_prompt_with_thinking(
             &self.inner.chat_template,
             &self.inner.tokenizer_config,
             messages,
+            enable_thinking,
         )?;
         let prompt = if multimodal.image.is_some() {
             interpolate_multimodal_prompt(

--- a/catgrad-llm/src/types/openai.rs
+++ b/catgrad-llm/src/types/openai.rs
@@ -64,6 +64,16 @@ pub struct StreamOptions {
     pub include_usage: Option<bool>,
 }
 
+/// Requested reasoning level for chat-completions.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ReasoningEffort {
+    None,
+    Low,
+    Medium,
+    High,
+}
+
 /// Chat-completions request.
 #[skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize, TypedBuilder, PartialEq)]
@@ -72,6 +82,8 @@ pub struct ChatCompletionRequest {
     pub messages: Vec<ChatMessage>,
     #[builder(default)]
     pub max_tokens: Option<u32>,
+    #[builder(default)]
+    pub reasoning_effort: Option<ReasoningEffort>,
     #[builder(default)]
     pub stream: Option<bool>,
     #[builder(default)]
@@ -248,6 +260,7 @@ mod tests {
                 }
             ],
             "max_tokens": 64,
+            "reasoning_effort": "medium",
             "stream": false,
             "stream_options": {"include_usage": true},
             "tools": [],
@@ -299,6 +312,7 @@ mod tests {
                         .build(),
                 ])
                 .max_tokens(Some(64))
+                .reasoning_effort(Some(ReasoningEffort::Medium))
                 .stream(Some(false))
                 .stream_options(Some(StreamOptions {
                     include_usage: Some(true),

--- a/catgrad-llm/src/utils/mod.rs
+++ b/catgrad-llm/src/utils/mod.rs
@@ -16,7 +16,7 @@ mod detokenize;
 pub use detokenize::{Detokenizer, detokenize_tokens};
 
 mod prompt;
-pub(crate) use prompt::render_chat_prompt;
+pub(crate) use prompt::render_chat_prompt_with_thinking;
 pub use prompt::{PreparedPrompt, render_chat_template};
 
 mod images;

--- a/catgrad-llm/src/utils/prompt.rs
+++ b/catgrad-llm/src/utils/prompt.rs
@@ -95,11 +95,20 @@ pub(crate) fn render_chat_prompt(
     tokenizer_config: &JsonValue,
     messages: &[types::Message],
 ) -> Result<String> {
+    render_chat_prompt_with_thinking(chat_template, tokenizer_config, messages, false)
+}
+
+pub(crate) fn render_chat_prompt_with_thinking(
+    chat_template: &str,
+    tokenizer_config: &JsonValue,
+    messages: &[types::Message],
+    enable_thinking: bool,
+) -> Result<String> {
     let messages: Vec<_> = messages
         .iter()
         .map(message_to_template_context)
         .collect::<Result<_>>()?;
-    render_chat_messages(chat_template, tokenizer_config, messages, false)
+    render_chat_messages(chat_template, tokenizer_config, messages, enable_thinking)
 }
 
 fn strftime_now(format_str: String) -> String {


### PR DESCRIPTION
Allow enabling thinking in API and example. Restricted to models that support this being set via the chat template. 